### PR TITLE
Add activity feed API

### DIFF
--- a/frontend/test-results/.last-run.json
+++ b/frontend/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for the activity feed
+const activityFeed = [
+  {
+    id: 1000,
+    title: 'New Photo Uploaded',
+    body: 'Alice uploaded a new photo to her album.'
+  },
+  {
+    id: 2000,
+    title: 'Comment on Post',
+    body: "Bob commented on Charlie's post."
+  },
+  {
+    id: 13,
+    title: 'Status Update',
+    body: 'Charlie updated their status: "Excited about the new project!"'
+  }
+];
+
+app.get('/feed', (req, res) => {
+  res.json(activityFeed);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
### TL;DR

Added a simple Express server for the Graphite demo and test results tracking.

### What changed?

- Created a new Express server in `graphite-demo/server.js` that serves mock activity feed data
- Added a `.last-run.json` file to track test results in the frontend directory

### How to test?

1. Navigate to the `graphite-demo` directory
2. Run `npm install express` (if not already installed)
3. Start the server with `node server.js`
4. Visit `http://localhost:3000/feed` in your browser to verify the activity feed data is returned

### Why make this change?

This change provides a simple backend server for the Graphite demo that serves mock activity feed data, which will be used by the frontend application. The test results tracking file helps maintain a record of test execution status for the frontend components.