### PR TITLE
Add Terms of Service and Privacy Policy pages

### DIFF
--- a/frontend/src/pages/privacy.tsx
+++ b/frontend/src/pages/privacy.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import Head from 'next/head';
+
+const PrivacyPage: React.FC = () => {
+    return (
+        <>
+            <Head>
+                <title>Privacy Policy | Ghostmonk</title>
+                <meta name="description" content="Privacy Policy for Ghostmonk" />
+            </Head>
+
+            <div className="page-container">
+                <h1 className="page-title">Privacy Policy</h1>
+
+                <div className="card">
+                    <div className="prose prose--card">
+                        <p><strong>Last updated:</strong> January 2, 2025</p>
+
+                        <h2>1. Introduction</h2>
+                        <p>
+                            This Privacy Policy explains how Ghostmonk (&quot;we&quot;, &quot;us&quot;, or &quot;our&quot;) collects, uses, and
+                            protects your information when you visit ghostmonk.com.
+                        </p>
+
+                        <h2>2. Information We Collect</h2>
+
+                        <h3>Information you provide</h3>
+                        <p>When you sign in with Google, we receive:</p>
+                        <ul>
+                            <li><strong>Email address:</strong> Used to identify your account</li>
+                            <li><strong>Name:</strong> Displayed with your comments</li>
+                            <li><strong>Profile picture:</strong> Displayed with your comments</li>
+                        </ul>
+
+                        <h3>Information collected automatically</h3>
+                        <p>We may collect standard web analytics data including:</p>
+                        <ul>
+                            <li>Pages visited and time spent</li>
+                            <li>Browser type and device information</li>
+                            <li>IP address (anonymized)</li>
+                            <li>Referring website</li>
+                        </ul>
+
+                        <h2>3. How We Use Your Information</h2>
+                        <p>We use your information to:</p>
+                        <ul>
+                            <li>Authenticate your account and display your identity on comments</li>
+                            <li>Enable reactions and comments on content</li>
+                            <li>Improve the website and user experience</li>
+                            <li>Prevent abuse and enforce our Terms of Service</li>
+                        </ul>
+
+                        <h2>4. Data Storage and Security</h2>
+                        <p>
+                            Your data is stored securely using industry-standard practices. We use encrypted
+                            connections (HTTPS) and secure cloud infrastructure to protect your information.
+                        </p>
+
+                        <h2>5. Third-Party Services</h2>
+                        <p>We use the following third-party services:</p>
+                        <ul>
+                            <li><strong>Google Authentication:</strong> For secure sign-in (governed by Google&apos;s Privacy Policy)</li>
+                            <li><strong>Google Cloud Platform:</strong> For hosting and data storage</li>
+                        </ul>
+
+                        <h2>6. Cookies</h2>
+                        <p>
+                            We use essential cookies to maintain your login session. These are necessary for the
+                            site to function and cannot be disabled while using authenticated features.
+                        </p>
+
+                        <h2>7. Your Rights</h2>
+                        <p>You have the right to:</p>
+                        <ul>
+                            <li><strong>Access:</strong> Request a copy of your personal data</li>
+                            <li><strong>Deletion:</strong> Request deletion of your account and associated data</li>
+                            <li><strong>Correction:</strong> Request correction of inaccurate data</li>
+                            <li><strong>Withdraw consent:</strong> Sign out and stop using authenticated features at any time</li>
+                        </ul>
+                        <p>
+                            To exercise these rights, please contact us using the contact form on this site.
+                        </p>
+
+                        <h2>8. Data Retention</h2>
+                        <p>
+                            We retain your account information and comments for as long as your account is active.
+                            Deleted comments are soft-deleted and may be fully purged after 30 days.
+                        </p>
+
+                        <h2>9. Children&apos;s Privacy</h2>
+                        <p>
+                            This site is not intended for children under 13. We do not knowingly collect
+                            information from children under 13.
+                        </p>
+
+                        <h2>10. Changes to This Policy</h2>
+                        <p>
+                            We may update this Privacy Policy from time to time. We will notify users of
+                            significant changes by updating the &quot;Last updated&quot; date.
+                        </p>
+
+                        <h2>11. Contact</h2>
+                        <p>
+                            For privacy-related questions or to exercise your data rights, please use the
+                            contact form on this site.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default PrivacyPage;

--- a/frontend/src/pages/terms.tsx
+++ b/frontend/src/pages/terms.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import Head from 'next/head';
+
+const TermsPage: React.FC = () => {
+    return (
+        <>
+            <Head>
+                <title>Terms of Service | Ghostmonk</title>
+                <meta name="description" content="Terms of Service for Ghostmonk" />
+            </Head>
+
+            <div className="page-container">
+                <h1 className="page-title">Terms of Service</h1>
+
+                <div className="card">
+                    <div className="prose prose--card">
+                        <p><strong>Last updated:</strong> January 2, 2025</p>
+
+                        <h2>1. Acceptance of Terms</h2>
+                        <p>
+                            By accessing and using this website (ghostmonk.com), you accept and agree to be bound by
+                            these Terms of Service. If you do not agree to these terms, please do not use this site.
+                        </p>
+
+                        <h2>2. Description of Service</h2>
+                        <p>
+                            Ghostmonk is a personal blog and portfolio website. Users may view content, and
+                            authenticated users may leave comments and reactions on published content.
+                        </p>
+
+                        <h2>3. User Accounts</h2>
+                        <p>
+                            To leave comments or reactions, you must sign in using Google authentication. By signing in,
+                            you agree to provide accurate information and to use the service in accordance with these terms.
+                        </p>
+
+                        <h2>4. User Conduct</h2>
+                        <p>You agree not to:</p>
+                        <ul>
+                            <li>Post content that is unlawful, harmful, threatening, abusive, harassing, defamatory, or otherwise objectionable</li>
+                            <li>Impersonate any person or entity</li>
+                            <li>Spam, advertise, or solicit without permission</li>
+                            <li>Attempt to interfere with or disrupt the service</li>
+                            <li>Collect or harvest user information without consent</li>
+                        </ul>
+
+                        <h2>5. Content Ownership</h2>
+                        <p>
+                            All original content on this site (articles, projects, images) is owned by Ghostmonk unless
+                            otherwise noted. Comments and reactions you submit remain your intellectual property, but you
+                            grant us a non-exclusive license to display them on the site.
+                        </p>
+
+                        <h2>6. Moderation</h2>
+                        <p>
+                            We reserve the right to remove any comments or content that violates these terms, and to
+                            restrict access to users who repeatedly violate these guidelines.
+                        </p>
+
+                        <h2>7. Disclaimer of Warranties</h2>
+                        <p>
+                            This site is provided &quot;as is&quot; without warranties of any kind. We do not guarantee that the
+                            service will be uninterrupted, secure, or error-free.
+                        </p>
+
+                        <h2>8. Limitation of Liability</h2>
+                        <p>
+                            Ghostmonk shall not be liable for any indirect, incidental, special, or consequential damages
+                            arising from your use of the service.
+                        </p>
+
+                        <h2>9. Changes to Terms</h2>
+                        <p>
+                            We may update these terms from time to time. Continued use of the site after changes
+                            constitutes acceptance of the new terms.
+                        </p>
+
+                        <h2>10. Contact</h2>
+                        <p>
+                            For questions about these terms, please use the contact form on this site.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default TermsPage;


### PR DESCRIPTION
Static pages required for Google OAuth production publishing:
- /terms - Terms of Service with user conduct, content ownership, disclaimers
- /privacy - Privacy Policy covering data collection, Google auth, user rights