### PR TITLE
fix: disable browser caching on API proxy and address review feedback

### DIFF
--- a/frontend/src/hooks/useActiveSection.ts
+++ b/frontend/src/hooks/useActiveSection.ts
@@ -1,15 +1,8 @@
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 import { getActiveSectionSlug, NavSectionItem } from '@/shared/lib/navigation';
-import { useNavSections } from './useNavSections';
 
-export function useActiveSection(): string | null {
-    const router = useRouter();
-    const sections = useNavSections();
-    return useMemo(() => getActiveSectionSlug(router.asPath, sections), [router.asPath, sections]);
-}
-
-export function useActiveSectionWith(sections: NavSectionItem[]): string | null {
+export function useActiveSection(sections: NavSectionItem[]): string {
     const router = useRouter();
     return useMemo(() => getActiveSectionSlug(router.asPath, sections), [router.asPath, sections]);
 }

--- a/frontend/src/hooks/useNavSections.ts
+++ b/frontend/src/hooks/useNavSections.ts
@@ -15,10 +15,7 @@ function fetchNavSections(): Promise<NavSectionItem[]> {
             cachedSections = items.length > 0 ? items : FALLBACK_SECTIONS;
             return cachedSections;
         })
-        .catch(() => {
-            cachedSections = FALLBACK_SECTIONS;
-            return cachedSections;
-        })
+        .catch(() => FALLBACK_SECTIONS)
         .finally(() => {
             fetchPromise = null;
         });

--- a/frontend/src/layout/BottomNav.tsx
+++ b/frontend/src/layout/BottomNav.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Link from 'next/link';
-import { useActiveSection } from '@/hooks/useActiveSection';
 import { useNavSections } from '@/hooks/useNavSections';
+import { useActiveSection } from '@/hooks/useActiveSection';
 import { NavSectionItem, NavIcon } from '@/shared/lib/navigation';
 import { HiHome, HiUser, HiFolder, HiMail, HiViewGrid } from 'react-icons/hi';
 
@@ -36,7 +36,7 @@ const NavItem: React.FC<NavItemProps> = ({ section, isActive }) => {
 
 const BottomNav: React.FC = () => {
     const sections = useNavSections();
-    const activeSlug = useActiveSection();
+    const activeSlug = useActiveSection(sections);
 
     return (
         <nav

--- a/frontend/src/layout/TopNav.tsx
+++ b/frontend/src/layout/TopNav.tsx
@@ -21,7 +21,7 @@ export default function TopNav() {
     const { data: session } = useSession();
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
     const sections = useNavSections();
-    const activeSlug = useActiveSection();
+    const activeSlug = useActiveSection(sections);
 
     const toggleMobileMenu = () => {
         setMobileMenuOpen(!mobileMenuOpen);

--- a/frontend/src/pages/api/stories.ts
+++ b/frontend/src/pages/api/stories.ts
@@ -63,44 +63,47 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     apiLogger.logApiRequest(req, res);
     
     try {
+        const token = await getToken({ req });
+        const isAuthenticated = !!token?.accessToken;
+
+        // No browser caching — the server-side in-memory cache handles
+        // performance. Browser caching causes stale responses to overwrite
+        // fresh server-rendered data on client-side mount fetches.
+        const cacheControl = 'private, no-store';
+
         // Check cache for GET requests
         if (req.method === 'GET') {
             const cacheKey = getCacheKey(req);
             const cachedData = getFromCache(cacheKey);
-            
+
             if (cachedData) {
                 apiLogger.info('Serving from cache', { cacheKey });
-                
-                // Set cache headers
-                res.setHeader('Cache-Control', 'public, max-age=120, stale-while-revalidate=300');
+
+                res.setHeader('Cache-Control', cacheControl);
                 res.setHeader('X-Cache', 'HIT');
-                
+
                 return res.status(200).json(cachedData);
             }
         }
 
         if (req.method !== 'GET') {
-            const token = await getToken({ req });
-            
-            if (!token || !token.accessToken) {
+            if (!isAuthenticated) {
                 const error = new Error('Authentication required');
                 apiLogger.error('Authentication failed', error, {
                     path: req.url,
                     method: req.method
                 });
-                return res.status(401).json({ 
+                return res.status(401).json({
                     detail: 'Not authenticated',
                     error: 'Authentication required'
                 });
             }
-            
+
             // Invalidate cache on mutations
             invalidateCache('stories');
         }
 
         let apiUrl = `${API_BASE_URL}/stories`;
-        
-        const token = await getToken({ req });
         
         if (req.method === 'GET' && req.query) {
             const params = new URLSearchParams();
@@ -180,7 +183,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
 
         const data = await response.json();
-        
+
+        // Revalidate home page ISR cache after mutations
+        if (req.method !== 'GET') {
+            try {
+                await res.revalidate('/');
+            } catch (revalidateErr) {
+                console.error('ISR revalidation failed:', revalidateErr);
+            }
+        }
+
         // Cache successful GET responses
         if (req.method === 'GET') {
             const cacheKey = getCacheKey(req);
@@ -190,8 +202,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             setCache(cacheKey, data, ttl);
             apiLogger.info('Cached response', { cacheKey, ttl });
             
-            // Set cache headers
-            res.setHeader('Cache-Control', 'public, max-age=120, stale-while-revalidate=300');
+            res.setHeader('Cache-Control', cacheControl);
             res.setHeader('X-Cache', 'MISS');
         }
         

--- a/frontend/src/pages/api/stories/[id].ts
+++ b/frontend/src/pages/api/stories/[id].ts
@@ -45,17 +45,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             if (!token?.accessToken) {
                 return res.status(401).json({ detail: 'Authentication required', error: 'Unauthorized' });
             }
-            
+
             // Only allow deletion by ID, not by slug
             if (!isObjectId) {
                 return res.status(400).json({ detail: 'Cannot delete by slug, ID required', error: 'Invalid request' });
             }
-            
+
             const response = await fetch(apiUrl, {
                 method: 'DELETE',
                 headers,
             });
-            
+
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
                 return res.status(response.status).json({
@@ -63,24 +63,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     status: response.status
                 });
             }
-            
+
+            try { await res.revalidate('/'); } catch { /* non-fatal */ }
             return res.status(204).end();
         } else if (req.method === 'PUT') {
             if (!token?.accessToken) {
                 return res.status(401).json({ detail: 'Authentication required', error: 'Unauthorized' });
             }
-            
+
             // Only allow updates by ID, not by slug
             if (!isObjectId) {
                 return res.status(400).json({ detail: 'Cannot update by slug, ID required', error: 'Invalid request' });
             }
-            
+
             const response = await fetch(apiUrl, {
                 method: 'PUT',
                 headers,
                 body: JSON.stringify(req.body),
             });
-            
+
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
                 return res.status(response.status).json({
@@ -88,8 +89,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                     status: response.status
                 });
             }
-            
+
             const data = await response.json();
+            try { await res.revalidate('/'); } catch { /* non-fatal */ }
             return res.status(200).json(data);
         } else if (req.method === 'GET') {
             const response = await fetch(apiUrl, { headers });

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -37,17 +37,17 @@ const Home: React.FC<HomeProps> = ({ initialStories, storySectionSlug, error }) 
 export const getStaticProps: GetStaticProps<HomeProps> = async () => {
     try {
         const backendUrl = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL;
-        
+
         if (!backendUrl) {
             return {
                 props: {
                     error: 'Backend URL not configured'
                 },
-                revalidate: 60 // Try again in 1 minute
+                revalidate: 60,
             };
         }
 
-        // Fetch initial stories for SSG
+        // Fetch initial stories for ISR
         const response = await fetch(`${backendUrl}/stories?limit=5&offset=0&include_drafts=false`, {
             headers: {
                 'Content-Type': 'application/json',
@@ -80,16 +80,16 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
                 initialStories: data,
                 storySectionSlug: storySectionSlug || null,
             },
-            revalidate: 300 // Revalidate every 5 minutes
+            revalidate: 300,
         };
     } catch (error) {
         console.error('Error in getStaticProps:', error);
-        
+
         return {
             props: {
                 error: error instanceof Error ? error.message : 'Failed to load stories'
             },
-            revalidate: 60 // Try again in 1 minute
+            revalidate: 60,
         };
     }
 };

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -199,33 +199,33 @@ const apiClient = {
    * Story methods
    */
   stories: {
-    list: (token?: string, pagination?: PaginationParams) => 
-      fetchApi<PaginatedResponse<Story>>(apiRoutes.stories.list(), { 
+    list: (token?: string, pagination?: PaginationParams) =>
+      fetchApi<PaginatedResponse<Story>>(apiRoutes.stories.list(), {
         token,
-        params: pagination as Record<string, string | number>
+        params: pagination as Record<string, string | number>,
       }),
-    
-    getById: (id: string, token: string) => 
+
+    getById: (id: string, token: string) =>
       fetchApi<Story>(apiRoutes.stories.getById(id), { token }),
-    
-    create: (data: CreateStoryRequest, token: string) => 
-      fetchApi<Story, CreateStoryRequest>(apiRoutes.stories.create(), { 
-        method: 'POST', 
-        body: data, 
-        token 
+
+    create: (data: CreateStoryRequest, token: string) =>
+      fetchApi<Story, CreateStoryRequest>(apiRoutes.stories.create(), {
+        method: 'POST',
+        body: data,
+        token,
       }),
-    
-    update: (id: string, data: Partial<Story>, token: string) => 
-      fetchApi<Story, Partial<Story>>(apiRoutes.stories.update(id), { 
-        method: 'PUT', 
-        body: data, 
-        token 
+
+    update: (id: string, data: Partial<Story>, token: string) =>
+      fetchApi<Story, Partial<Story>>(apiRoutes.stories.update(id), {
+        method: 'PUT',
+        body: data,
+        token,
       }),
-    
+
     delete: (id: string, token: string) =>
       fetchApi<Story>(apiRoutes.stories.delete(id), {
         method: 'DELETE',
-        token
+        token,
       }),
   },
 

--- a/frontend/src/shared/lib/navigation.ts
+++ b/frontend/src/shared/lib/navigation.ts
@@ -17,7 +17,7 @@ const SLUG_ICON_MAP: Record<string, NavIcon> = {
 };
 
 export const FALLBACK_SECTIONS: NavSectionItem[] = [
-    { slug: 'blog', path: '/', label: 'Blog', icon: 'home' },
+    { slug: 'blog', path: '/blog', label: 'Blog', icon: 'home' },
     { slug: 'about', path: '/about', label: 'About', icon: 'user' },
     { slug: 'projects', path: '/projects', label: 'Projects', icon: 'folder' },
     { slug: 'contact', path: '/contact', label: 'Contact', icon: 'mail' },
@@ -36,15 +36,11 @@ export function sectionsToNavItems(sections: Section[]): NavSectionItem[] {
     return sections.map(sectionToNavItem);
 }
 
-export function getActiveSectionSlug(pathname: string, sections: NavSectionItem[]): string | null {
-    if (pathname === '/') return 'blog';
+const DEFAULT_SECTION_SLUG = 'blog';
 
+export function getActiveSectionSlug(pathname: string, sections: NavSectionItem[]): string {
     const firstSegment = pathname.split('/').filter(Boolean)[0];
-    if (!firstSegment) return 'blog';
+    if (!firstSegment) return DEFAULT_SECTION_SLUG;
 
-    const match = sections.find(s => s.slug === firstSegment);
-    if (match) return match.slug;
-
-    // Story detail pages (e.g., /blog/some-story) — check if first segment matches any section
-    return sections.find(s => pathname.startsWith(s.path + '/'))?.slug || 'blog';
+    return sections.find(s => s.slug === firstSegment)?.slug || DEFAULT_SECTION_SLUG;
 }


### PR DESCRIPTION
## Summary
- Remove browser `Cache-Control` headers from `/api/stories` proxy to prevent stale cached responses from overwriting fresh server-rendered data on client mount fetches. Server-side in-memory cache still handles performance.
- Address all items from claude[bot] review on PR #122: fix permanent fallback caching on transient API failure, fix blog path inconsistency, remove dead code in `getActiveSectionSlug`, fix return type, consolidate `useActiveSection` hook to eliminate double `useNavSections` calls, extract `DEFAULT_SECTION_SLUG` constant.

## Test plan
- [ ] Publish a story and verify it persists on home page without flash-and-disappear
- [ ] Verify anonymous users see stories without flash
- [ ] Verify nav sections fall back gracefully on API failure and retry on next mount
- [ ] Verify active nav highlighting works on all section routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)