### PR TITLE
Phase 6: Section-aware editor and admin section management

### DIFF
--- a/docs-site/pages/plans/2026-03-01-phase-6-section-editor.md
+++ b/docs-site/pages/plans/2026-03-01-phase-6-section-editor.md
@@ -1,0 +1,182 @@
+# Phase 6: Section & Content Management
+
+**Goal:** Make the editor section-aware — admins can create/edit/delete sections and create content for any section type, with the editor form adapting to the section's content_type.
+
+**Architecture:** Add section CRUD proxy routes and api-client methods, create an `/admin/sections` management page, refactor the editor page to accept a `section_id` and render content-type-specific forms (story, project, page). Reuse existing backend API (no backend changes).
+
+**Tech Stack:** Next.js, TypeScript, NextAuth, TipTap, Playwright e2e
+
+---
+
+## Context
+
+Dynamic Sections Phases 1-5 are released. The backend has full section CRUD. The frontend has a registry system mapping `display_type`/`content_type` to React components, dynamic routing via `[...slugPath].tsx`, and database-driven navigation. But the editor only creates stories — there's no UI for managing sections or creating content for different section types.
+
+---
+
+## Batch 1: API Layer
+
+### Task 1: Add section CRUD types
+
+**Files:**
+- Modify: `frontend/src/shared/types/api.ts`
+
+**Steps:**
+1. Add `section_id?: string` to `Story`, `CreateStoryRequest`, `Project`, `ProjectCard`, `CreateProjectRequest`
+2. Add `CreateSectionRequest` and `UpdateSectionRequest` interfaces
+3. Verify: `cd frontend && npx tsc --noEmit`
+
+### Task 2: Add section CRUD proxy routes
+
+**Files:**
+- Create: `frontend/src/pages/api/sections/index.ts` (GET list + POST create)
+- Create: `frontend/src/pages/api/sections/[id].ts` (GET + PUT + DELETE by ID)
+
+**Pattern:** Follow `pages/api/stories/[id].ts`. Existing `pages/api/sections/navigation.ts` and `pages/api/sections/by-slug/[slug].ts` must not be disturbed.
+
+### Task 3: Add section CRUD methods to api-client
+
+**Files:**
+- Modify: `frontend/src/shared/lib/api-client.ts`
+
+**Steps:**
+1. Add to `apiRoutes.sections`: `list`, `getById`, `create`, `update`, `delete` (keep existing `getBySlug`, `navigation`)
+2. Add to `apiClient.sections`: `list(token, params?)`, `getById(id, token)`, `create(data, token)`, `update(id, data, token)`, `delete(id, token)`
+3. Verify: `npx tsc --noEmit`
+4. Commit batch 1
+
+---
+
+## Batch 2: Section Management Page
+
+### Task 4: Create sections module with hooks
+
+**Files:**
+- Create: `frontend/src/modules/sections/hooks/useSectionMutations.ts`
+- Create: `frontend/src/modules/sections/hooks/useFetchSections.ts`
+- Create: `frontend/src/modules/sections/hooks/index.ts`
+- Create: `frontend/src/modules/sections/index.ts`
+
+**Pattern:** Follow `modules/stories/hooks/useStoryMutations.ts` for mutations, simple fetch-on-mount for list.
+
+### Task 5: Create /admin/sections page
+
+**Files:**
+- Create: `frontend/src/pages/admin/sections.tsx`
+
+**Internal components:**
+- `SectionCreateForm` — title, display_type select, content_type select, nav_visibility select
+- `SectionRow` — shows section with Edit/Delete/"Add Content" buttons
+- `SectionEditForm` — inline edit, same fields as create, pre-filled
+
+**Behavior:** Auth guard (redirect non-admin), list all sections, CRUD operations, "Add Content" navigates to `/editor?section_id={id}`
+
+### Task 6: Add nav cache invalidation and admin links
+
+**Files:**
+- Modify: `frontend/src/hooks/useNavSections.ts` — export `invalidateNavCache()`
+- Modify: `frontend/src/shared/lib/navigation.ts` — add `id` to `NavSectionItem`
+- Modify: `frontend/src/layout/TopNav.tsx` — add "Sections" admin link, context-aware "New" button using active section ID
+
+Commit batch 2.
+
+---
+
+## Batch 3: Section-Aware Editor
+
+### Task 7: Extract story editor form component
+
+**Files:**
+- Create: `frontend/src/modules/editor/components/StoryEditorForm.tsx`
+- Modify: `frontend/src/modules/editor/hooks/useStoryEditor.ts` — accept `sectionId` param, include in save payload
+
+Extract current form from `editor.tsx` (TitleInput, ContentEditor, PublishToggle, FormActions, EditorHeader) into `StoryEditorForm`. Props: `section: Section`, `storyId?: string`.
+
+### Task 8: Create project editor form
+
+**Files:**
+- Create: `frontend/src/modules/editor/hooks/useProjectEditor.ts`
+- Create: `frontend/src/modules/editor/components/ProjectEditorForm.tsx`
+
+**Fields:** title, summary (textarea), content (RichTextEditor), technologies (comma-separated input), github_url, live_url, image_url, is_featured checkbox, sort_order, is_published. Uses `apiClient.projects.create/update`.
+
+### Task 9: Create page editor form and refactor editor.tsx
+
+**Files:**
+- Create: `frontend/src/modules/editor/components/PageEditorForm.tsx`
+- Modify: `frontend/src/pages/editor.tsx` — refactor to thin shell
+
+**Refactored editor.tsx:**
+1. Read `section_id` and `id` from `router.query`
+2. If `id` (editing): fetch item, determine section from `section_id`
+3. If `section_id` (new): fetch section for `content_type`
+4. If neither: show `SectionPicker` dropdown
+5. Render correct form based on `content_type`: story → `StoryEditorForm`, project → `ProjectEditorForm`, page → `PageEditorForm`
+
+Commit batch 3.
+
+---
+
+## Batch 4: E2E Tests
+
+### Task 10: Add section test data and mock routes
+
+**Files:**
+- Modify: `frontend/e2e/test-data.ts` — add `createTestSection()`
+- Modify: `frontend/e2e/fixtures/api-mock.fixture.ts` — section CRUD mocks
+- Modify: `frontend/e2e/mock-server.ts` — section endpoints
+
+### Task 11: Admin sections page e2e tests
+
+**Files:**
+- Create: `frontend/e2e/page-objects/admin-sections.page.ts`
+- Create: `frontend/e2e/specs/admin/sections.spec.ts`
+
+**Tests:** page loads for admin, non-admin redirect, CRUD operations, "Add Content" navigation
+
+### Task 12: Section-aware editor e2e tests
+
+**Files:**
+- Create: `frontend/e2e/specs/editor/section-editor.spec.ts`
+
+**Tests:** correct form per content_type, section picker without params, section_id in save payload
+
+Commit batch 4.
+
+---
+
+## Verification
+
+1. `make dev` — start local stack
+2. Log in as admin → `/admin/sections` — see blog, about, projects, contact
+3. Create section → appears in navigation
+4. Edit section title → slug updates
+5. Delete section → removed from navigation
+6. `/editor` → section picker shown
+7. `/editor?section_id=<blog-id>` → story form
+8. `/editor?section_id=<projects-id>` → project form
+9. "Add Content" from admin page → correct editor form
+10. `npx playwright test` — all pass
+
+---
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `frontend/src/shared/types/api.ts` | Types — updated first |
+| `frontend/src/shared/lib/api-client.ts` | Section CRUD methods |
+| `frontend/src/pages/api/sections/index.ts` | Proxy: list + create |
+| `frontend/src/pages/api/sections/[id].ts` | Proxy: get + update + delete |
+| `frontend/src/pages/admin/sections.tsx` | Admin management page |
+| `frontend/src/pages/editor.tsx` | Refactored to section-aware shell |
+| `frontend/src/modules/editor/hooks/useStoryEditor.ts` | Add section_id support |
+| `frontend/src/modules/editor/hooks/useProjectEditor.ts` | New — project editor state |
+| `frontend/src/modules/editor/components/StoryEditorForm.tsx` | New — extracted story form |
+| `frontend/src/modules/editor/components/ProjectEditorForm.tsx` | New — project form |
+| `frontend/src/modules/editor/components/PageEditorForm.tsx` | New — page form |
+| `frontend/src/modules/sections/hooks/useSectionMutations.ts` | New — section CRUD hook |
+| `frontend/src/modules/sections/hooks/useFetchSections.ts` | New — fetch sections hook |
+| `frontend/src/hooks/useNavSections.ts` | Add invalidateNavCache |
+| `frontend/src/shared/lib/navigation.ts` | Add id to NavSectionItem |
+| `frontend/src/layout/TopNav.tsx` | Admin links, context-aware "New" |

--- a/docs-site/pages/plans/_meta.ts
+++ b/docs-site/pages/plans/_meta.ts
@@ -1,5 +1,6 @@
 export default {
   index: 'Overview',
+  '2026-03-01-phase-6-section-editor': 'Phase 6: Section Editor',
   '2026-02-27-phase4-dynamic-routing': 'Phase 4: Dynamic Routing',
   '2026-01-04-phase-4-stories-module': 'Stories Module',
   '2026-01-04-phase-3-layout-extraction': 'Layout Extraction',

--- a/frontend/e2e/fixtures/api-mock.fixture.ts
+++ b/frontend/e2e/fixtures/api-mock.fixture.ts
@@ -16,6 +16,7 @@ import {
   TestComment,
   projectToCard,
   createTestComment,
+  createTestSection,
 } from '../test-data';
 
 /**
@@ -647,6 +648,81 @@ async function setupApiMocks(page: Page, options: ApiMockOptions = {}) {
         contentType: 'application/json',
         body: JSON.stringify({ detail: 'Section not found' }),
       });
+    }
+  });
+
+  // Mock sections list endpoint (GET /api/sections)
+  await page.route(/\/api\/sections\/?(\?|$)/, async (route) => {
+    await maybeDelay();
+    const method = route.request().method();
+
+    if (method === 'POST') {
+      if (failRequests) {
+        await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ detail: 'Internal server error' }) });
+        return;
+      }
+      const body = route.request().postDataJSON();
+      const newSection = createTestSection({
+        ...body,
+        id: `section-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+        slug: body.title?.toLowerCase().replace(/\s+/g, '-') || 'new-section',
+      });
+      await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(newSection) });
+      return;
+    }
+
+    if (failRequests) {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ detail: 'Internal server error' }) });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        items: sections,
+        total: sections.length,
+        limit: 20,
+        offset: 0,
+      }),
+    });
+  });
+
+  // Mock section by ID endpoint (GET/PUT/DELETE /api/sections/{id})
+  await page.route(/\/api\/sections\/(?!by-slug|navigation)[\w-]+$/, async (route) => {
+    await maybeDelay();
+    const method = route.request().method();
+    const urlObj = new URL(route.request().url());
+    const pathParts = urlObj.pathname.split('/');
+    const id = pathParts[pathParts.length - 1];
+
+    if (failRequests) {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ detail: 'Internal server error' }) });
+      return;
+    }
+
+    if (method === 'DELETE') {
+      await route.fulfill({ status: 204 });
+      return;
+    }
+
+    if (method === 'PUT') {
+      const body = route.request().postDataJSON();
+      const existing = sections.find((s) => s.id === id);
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ...(existing || {}), ...body, id }),
+      });
+      return;
+    }
+
+    // GET
+    const section = sections.find((s) => s.id === id);
+    if (section) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(section) });
+    } else {
+      await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: 'Section not found' }) });
     }
   });
 

--- a/frontend/e2e/mock-server.ts
+++ b/frontend/e2e/mock-server.ts
@@ -9,6 +9,7 @@ import {
   sampleReactions,
   sampleComments,
   createTestComment,
+  createTestSection,
 } from './test-data';
 
 const app = express();
@@ -322,6 +323,41 @@ app.get('/sections/by-slug/:slug', (req: Request, res: Response) => {
   } else {
     res.status(404).json({ detail: 'Section not found' });
   }
+});
+
+// GET /sections/:id - Get section by ID
+app.get('/sections/:id', (req: Request, res: Response) => {
+  const section = sections.find((s) => s.id === req.params.id);
+  if (section) {
+    res.json(section);
+  } else {
+    res.status(404).json({ detail: 'Section not found' });
+  }
+});
+
+// POST /sections - Create section (returns success but doesn't persist)
+app.post('/sections', (req: Request, res: Response) => {
+  const newSection = createTestSection({
+    ...req.body,
+    id: `section-${Date.now()}`,
+    slug: req.body.title?.toLowerCase().replace(/\s+/g, '-') || 'new-section',
+  });
+  res.status(201).json(newSection);
+});
+
+// PUT /sections/:id - Update section (returns success but doesn't persist)
+app.put('/sections/:id', (req: Request, res: Response) => {
+  const section = sections.find((s) => s.id === req.params.id);
+  if (section) {
+    res.json({ ...section, ...req.body, updatedDate: FIXED_TIMESTAMP });
+  } else {
+    res.status(404).json({ detail: 'Section not found' });
+  }
+});
+
+// DELETE /sections/:id - Delete section
+app.delete('/sections/:id', (req: Request, res: Response) => {
+  res.status(204).send();
 });
 
 // Health check

--- a/frontend/e2e/page-objects/admin-sections.page.ts
+++ b/frontend/e2e/page-objects/admin-sections.page.ts
@@ -1,0 +1,96 @@
+import { Page, Locator } from '@playwright/test';
+import { BasePage } from './base.page';
+import { TopNavComponent } from './components/top-nav.component';
+
+export class AdminSectionsPage extends BasePage {
+  readonly nav: TopNavComponent;
+
+  readonly pageContainer: Locator;
+  readonly createButton: Locator;
+  readonly sectionsList: Locator;
+
+  // Create form
+  readonly createForm: Locator;
+  readonly titleInput: Locator;
+  readonly displayTypeSelect: Locator;
+  readonly contentTypeSelect: Locator;
+  readonly navVisibilitySelect: Locator;
+  readonly createSubmitButton: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.nav = new TopNavComponent(page);
+
+    this.pageContainer = page.getByTestId('admin-sections-page');
+    this.createButton = page.getByTestId('create-section-button');
+    this.sectionsList = page.getByTestId('sections-list');
+
+    this.createForm = page.getByTestId('section-create-form');
+    this.titleInput = page.getByTestId('section-title-input');
+    this.displayTypeSelect = page.getByTestId('section-display-type-select');
+    this.contentTypeSelect = page.getByTestId('section-content-type-select');
+    this.navVisibilitySelect = page.getByTestId('section-nav-visibility-select');
+    this.createSubmitButton = page.getByTestId('section-create-submit');
+  }
+
+  async goto() {
+    await super.goto('/admin/sections');
+  }
+
+  async waitForPage() {
+    await this.pageContainer.waitFor({ state: 'visible' });
+  }
+
+  sectionRow(sectionId: string): Locator {
+    return this.page.getByTestId(`section-row-${sectionId}`);
+  }
+
+  editButton(sectionId: string): Locator {
+    return this.page.getByTestId(`section-edit-${sectionId}`);
+  }
+
+  deleteButton(sectionId: string): Locator {
+    return this.page.getByTestId(`section-delete-${sectionId}`);
+  }
+
+  addContentButton(sectionId: string): Locator {
+    return this.page.getByTestId(`section-add-content-${sectionId}`);
+  }
+
+  editForm(sectionId: string): Locator {
+    return this.page.getByTestId(`section-edit-form-${sectionId}`);
+  }
+
+  editTitleInput(sectionId: string): Locator {
+    return this.page.getByTestId(`section-edit-title-${sectionId}`);
+  }
+
+  editSubmitButton(sectionId: string): Locator {
+    return this.page.getByTestId(`section-edit-submit-${sectionId}`);
+  }
+
+  editCancelButton(sectionId: string): Locator {
+    return this.page.getByTestId(`section-edit-cancel-${sectionId}`);
+  }
+
+  async openCreateForm() {
+    await this.createButton.click();
+    await this.createForm.waitFor({ state: 'visible' });
+  }
+
+  async fillCreateForm(options: {
+    title: string;
+    displayType?: string;
+    contentType?: string;
+    navVisibility?: string;
+  }) {
+    await this.titleInput.fill(options.title);
+    if (options.displayType) await this.displayTypeSelect.selectOption(options.displayType);
+    if (options.contentType) await this.contentTypeSelect.selectOption(options.contentType);
+    if (options.navVisibility) await this.navVisibilitySelect.selectOption(options.navVisibility);
+  }
+
+  async submitCreateForm() {
+    await this.createSubmitButton.click();
+  }
+}

--- a/frontend/e2e/page-objects/components/top-nav.component.ts
+++ b/frontend/e2e/page-objects/components/top-nav.component.ts
@@ -9,7 +9,8 @@ export class TopNavComponent {
 
   // Navigation elements
   readonly nav: Locator;
-  readonly newStoryLink: Locator;
+  readonly newContentLink: Locator;
+  readonly sectionsLink: Locator;
 
   // Section links (desktop)
   readonly blogLink: Locator;
@@ -25,14 +26,16 @@ export class TopNavComponent {
   // Mobile menu
   readonly mobileMenuToggle: Locator;
   readonly mobileMenu: Locator;
-  readonly mobileNewStoryLink: Locator;
+  readonly mobileNewContentLink: Locator;
+  readonly mobileSectionsLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
     // Navigation
     this.nav = page.getByTestId('top-nav');
-    this.newStoryLink = page.getByTestId('nav-new-story-link');
+    this.newContentLink = page.getByTestId('nav-new-content-link');
+    this.sectionsLink = page.getByTestId('nav-sections-link');
 
     // Section links
     this.blogLink = page.getByTestId('nav-blog-link');
@@ -48,7 +51,8 @@ export class TopNavComponent {
     // Mobile
     this.mobileMenuToggle = page.getByTestId('mobile-menu-toggle');
     this.mobileMenu = page.getByTestId('mobile-menu');
-    this.mobileNewStoryLink = page.getByTestId('mobile-nav-new-story-link');
+    this.mobileNewContentLink = page.getByTestId('mobile-nav-new-content-link');
+    this.mobileSectionsLink = page.getByTestId('mobile-nav-sections-link');
   }
 
   /**
@@ -94,10 +98,17 @@ export class TopNavComponent {
   /**
    * Navigate to new story page.
    */
-  async goToNewStory() {
+  async goToNewContent() {
     await Promise.all([
-      this.page.waitForURL('**/editor'),
-      this.newStoryLink.click(),
+      this.page.waitForURL('**/editor**'),
+      this.newContentLink.click(),
+    ]);
+  }
+
+  async goToSections() {
+    await Promise.all([
+      this.page.waitForURL('**/admin/sections'),
+      this.sectionsLink.click(),
     ]);
   }
 

--- a/frontend/e2e/page-objects/editor.page.ts
+++ b/frontend/e2e/page-objects/editor.page.ts
@@ -38,17 +38,17 @@ export class EditorPage extends BasePage {
   }
 
   /**
-   * Navigate to the editor page (new story).
+   * Navigate to the editor page for a specific section.
    */
-  async goto() {
-    await super.goto('/editor');
+  async goto(sectionId: string) {
+    await super.goto(`/editor?section_id=${sectionId}`);
   }
 
   /**
-   * Navigate to edit an existing story.
+   * Navigate to edit an existing story within a section.
    */
-  async gotoEdit(storyId: string) {
-    await super.goto(`/editor?id=${storyId}`);
+  async gotoEdit(storyId: string, sectionId: string) {
+    await super.goto(`/editor?id=${storyId}&section_id=${sectionId}`);
   }
 
   /**
@@ -102,7 +102,7 @@ export class EditorPage extends BasePage {
    */
   async cancel() {
     await this.cancelButton.click();
-    await this.page.waitForURL('/', { timeout: 10000 });
+    await this.page.waitForURL(/^(?!.*\/editor)/, { timeout: 10000 });
   }
 
   /**

--- a/frontend/e2e/specs/admin/sections.spec.ts
+++ b/frontend/e2e/specs/admin/sections.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '../../fixtures/api-mock.fixture';
+import { AdminSectionsPage } from '../../page-objects/admin-sections.page';
+import { TEST_SECTION_IDS } from '../../test-data';
+
+test.describe('Admin Sections Page', () => {
+  test('loads for admin users and shows all sections', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    // All 4 sections should be visible
+    await expect(page.sectionRow(TEST_SECTION_IDS.BLOG)).toBeVisible();
+    await expect(page.sectionRow(TEST_SECTION_IDS.ABOUT)).toBeVisible();
+    await expect(page.sectionRow(TEST_SECTION_IDS.PROJECTS)).toBeVisible();
+    await expect(page.sectionRow(TEST_SECTION_IDS.CONTACT)).toBeVisible();
+  });
+
+  test('redirects non-admin users', async ({ mockApiPage }) => {
+    await mockApiPage.goto('/admin/sections');
+    // Should redirect to home since unauthenticated
+    await mockApiPage.waitForURL('/', { timeout: 10000 });
+  });
+
+  test('shows create form when New Section button is clicked', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    await expect(page.createForm).not.toBeVisible();
+    await page.openCreateForm();
+    await expect(page.createForm).toBeVisible();
+    await expect(page.titleInput).toBeVisible();
+    await expect(page.displayTypeSelect).toBeVisible();
+    await expect(page.contentTypeSelect).toBeVisible();
+    await expect(page.navVisibilitySelect).toBeVisible();
+  });
+
+  test('creates a section', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    await page.openCreateForm();
+    await page.fillCreateForm({
+      title: 'Gallery',
+      displayType: 'gallery',
+      contentType: 'image',
+      navVisibility: 'main',
+    });
+
+    // Intercept the POST to verify it fires
+    const createPromise = mockAuthenticatedApiPage.waitForRequest(
+      (req) => req.url().includes('/api/sections') && req.method() === 'POST'
+    );
+
+    await page.submitCreateForm();
+    const createRequest = await createPromise;
+    const body = createRequest.postDataJSON();
+    expect(body.title).toBe('Gallery');
+    expect(body.display_type).toBe('gallery');
+    expect(body.content_type).toBe('image');
+  });
+
+  test('opens edit form for a section', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    await page.editButton(TEST_SECTION_IDS.BLOG).click();
+    await expect(page.editForm(TEST_SECTION_IDS.BLOG)).toBeVisible();
+    await expect(page.editTitleInput(TEST_SECTION_IDS.BLOG)).toHaveValue('Blog');
+  });
+
+  test('cancels edit form', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    await page.editButton(TEST_SECTION_IDS.BLOG).click();
+    await expect(page.editForm(TEST_SECTION_IDS.BLOG)).toBeVisible();
+
+    await page.editCancelButton(TEST_SECTION_IDS.BLOG).click();
+    await expect(page.editForm(TEST_SECTION_IDS.BLOG)).not.toBeVisible();
+    await expect(page.sectionRow(TEST_SECTION_IDS.BLOG)).toBeVisible();
+  });
+
+  test('saves section edits', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    await page.editButton(TEST_SECTION_IDS.BLOG).click();
+    await page.editTitleInput(TEST_SECTION_IDS.BLOG).fill('Updated Blog');
+
+    const updatePromise = mockAuthenticatedApiPage.waitForRequest(
+      (req) => req.url().includes(`/api/sections/${TEST_SECTION_IDS.BLOG}`) && req.method() === 'PUT'
+    );
+
+    await page.editSubmitButton(TEST_SECTION_IDS.BLOG).click();
+    const updateRequest = await updatePromise;
+    const body = updateRequest.postDataJSON();
+    expect(body.title).toBe('Updated Blog');
+  });
+
+  test('deletes a section after confirmation', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    // Accept the confirmation dialog
+    mockAuthenticatedApiPage.on('dialog', (dialog) => dialog.accept());
+
+    const deletePromise = mockAuthenticatedApiPage.waitForRequest(
+      (req) => req.url().includes(`/api/sections/${TEST_SECTION_IDS.CONTACT}`) && req.method() === 'DELETE'
+    );
+
+    await page.deleteButton(TEST_SECTION_IDS.CONTACT).click();
+    await deletePromise;
+  });
+
+  test('Add Content navigates to editor with section_id', async ({ mockAuthenticatedApiPage }) => {
+    const page = new AdminSectionsPage(mockAuthenticatedApiPage);
+    await page.goto();
+    await page.waitForPage();
+
+    await page.addContentButton(TEST_SECTION_IDS.BLOG).click();
+    await mockAuthenticatedApiPage.waitForURL(`**/editor?section_id=${TEST_SECTION_IDS.BLOG}`, { timeout: 10000 });
+  });
+});

--- a/frontend/e2e/specs/editor/create-story.spec.ts
+++ b/frontend/e2e/specs/editor/create-story.spec.ts
@@ -1,11 +1,13 @@
-import { test, expect } from '../../fixtures';
+import { test, expect, TEST_SECTION_IDS } from '../../fixtures';
 import { EditorPage } from '../../page-objects/editor.page';
+
+const BLOG_SECTION_ID = TEST_SECTION_IDS.BLOG;
 
 test.describe('Create Story', () => {
   test('editor page loads for authenticated user', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Verify editor elements are visible
@@ -20,7 +22,7 @@ test.describe('Create Story', () => {
   test('title input accepts text', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.setTitle('My Test Story');
@@ -32,7 +34,7 @@ test.describe('Create Story', () => {
   test('rich text editor accepts content', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.richTextEditor.type('This is my story content');
@@ -44,7 +46,7 @@ test.describe('Create Story', () => {
   test('publish toggle can be toggled', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Default state
@@ -60,7 +62,7 @@ test.describe('Create Story', () => {
   test('save button reflects publish state', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // With publish unchecked
@@ -74,22 +76,22 @@ test.describe('Create Story', () => {
     expect(buttonText).toContain('Publish');
   });
 
-  test('cancel button navigates to home', async ({ mockAuthenticatedApiPage }) => {
+  test('cancel button navigates to section page', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.cancel();
 
-    // Should be on home page
-    expect(editorPage.url).toBe('http://localhost:3000/');
+    // Should navigate to the section page
+    expect(editorPage.url).toBe('http://localhost:3000/blog');
   });
 
   test('toolbar buttons are visible', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Verify all toolbar buttons are visible
@@ -110,8 +112,8 @@ test.describe('Create Story', () => {
     // Start from home
     await mockAuthenticatedApiPage.goto('/');
 
-    // Click new story link
-    await editorPage.nav.goToNewStory();
+    // Click new content link
+    await editorPage.nav.goToNewContent();
 
     // Should be on editor page
     expect(editorPage.url).toContain('/editor');

--- a/frontend/e2e/specs/editor/edit-story.spec.ts
+++ b/frontend/e2e/specs/editor/edit-story.spec.ts
@@ -1,12 +1,14 @@
-import { test, expect, TEST_STORY_IDS } from '../../fixtures';
+import { test, expect, TEST_STORY_IDS, TEST_SECTION_IDS } from '../../fixtures';
 import { EditorPage } from '../../page-objects/editor.page';
 import { HomePage } from '../../page-objects/home.page';
+
+const BLOG_SECTION_ID = TEST_SECTION_IDS.BLOG;
 
 test.describe('Edit Story', () => {
   test('loads existing story in edit mode', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.gotoEdit(TEST_STORY_IDS.PUBLISHED);
+    await editorPage.gotoEdit(TEST_STORY_IDS.PUBLISHED, BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Verify in edit mode
@@ -21,7 +23,7 @@ test.describe('Edit Story', () => {
   test('displays story title in edit mode', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.gotoEdit(TEST_STORY_IDS.PUBLISHED);
+    await editorPage.gotoEdit(TEST_STORY_IDS.PUBLISHED, BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Wait for form to populate
@@ -35,14 +37,15 @@ test.describe('Edit Story', () => {
   test('new button resets form', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.gotoEdit(TEST_STORY_IDS.PUBLISHED);
+    await editorPage.gotoEdit(TEST_STORY_IDS.PUBLISHED, BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Click new button
     await editorPage.clickNew();
 
-    // URL should no longer have id param
-    expect(editorPage.url).not.toContain('id=');
+    // URL should no longer have story id param (but keeps section_id)
+    const url = new URL(editorPage.url);
+    expect(url.searchParams.has('id')).toBe(false);
   });
 
   test('navigating from story list edit button', async ({ mockAuthenticatedApiPage }) => {

--- a/frontend/e2e/specs/editor/rich-text.spec.ts
+++ b/frontend/e2e/specs/editor/rich-text.spec.ts
@@ -1,11 +1,13 @@
-import { test, expect } from '../../fixtures';
+import { test, expect, TEST_SECTION_IDS } from '../../fixtures';
 import { EditorPage } from '../../page-objects/editor.page';
+
+const BLOG_SECTION_ID = TEST_SECTION_IDS.BLOG;
 
 test.describe('Rich Text Editor', () => {
   test('bold formatting works', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Click bold first, then type (toggle mode)
@@ -20,7 +22,7 @@ test.describe('Rich Text Editor', () => {
   test('italic formatting works', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Click italic first, then type (toggle mode)
@@ -34,7 +36,7 @@ test.describe('Rich Text Editor', () => {
   test('h1 heading works', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.richTextEditor.type('Title');
@@ -47,7 +49,7 @@ test.describe('Rich Text Editor', () => {
   test('h2 heading works', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.richTextEditor.type('Subtitle');
@@ -60,7 +62,7 @@ test.describe('Rich Text Editor', () => {
   test('bullet list works', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.richTextEditor.type('Item 1');
@@ -74,7 +76,7 @@ test.describe('Rich Text Editor', () => {
   test('ordered list works', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.richTextEditor.type('Step 1');
@@ -88,7 +90,7 @@ test.describe('Rich Text Editor', () => {
   test('blockquote works', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     await editorPage.richTextEditor.type('A famous quote');
@@ -101,7 +103,7 @@ test.describe('Rich Text Editor', () => {
   test('multiple formatting can be combined', async ({ mockAuthenticatedApiPage }) => {
     const editorPage = new EditorPage(mockAuthenticatedApiPage);
 
-    await editorPage.goto();
+    await editorPage.goto(BLOG_SECTION_ID);
     await editorPage.waitForEditor();
 
     // Toggle both formats then type

--- a/frontend/e2e/specs/editor/section-editor.spec.ts
+++ b/frontend/e2e/specs/editor/section-editor.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from '../../fixtures/api-mock.fixture';
+import { TEST_SECTION_IDS } from '../../test-data';
+
+test.describe('Section-Aware Editor', () => {
+  test('shows section picker when no section_id is provided', async ({ mockAuthenticatedApiPage }) => {
+    await mockAuthenticatedApiPage.goto('/editor');
+    await mockAuthenticatedApiPage.getByTestId('section-picker').waitFor({ state: 'visible' });
+
+    // Should show editable sections (story, project, page types)
+    await expect(mockAuthenticatedApiPage.getByTestId('section-picker-blog')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('section-picker-about')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('section-picker-projects')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('section-picker-contact')).toBeVisible();
+  });
+
+  test('clicking section picker navigates to editor with section_id', async ({ mockAuthenticatedApiPage }) => {
+    await mockAuthenticatedApiPage.goto('/editor');
+    await mockAuthenticatedApiPage.getByTestId('section-picker').waitFor({ state: 'visible' });
+
+    await mockAuthenticatedApiPage.getByTestId('section-picker-blog').click();
+    await mockAuthenticatedApiPage.waitForURL(`**/editor?section_id=${TEST_SECTION_IDS.BLOG}`, { timeout: 10000 });
+  });
+
+  test('renders story editor form for story content_type', async ({ mockAuthenticatedApiPage }) => {
+    await mockAuthenticatedApiPage.goto(`/editor?section_id=${TEST_SECTION_IDS.BLOG}`);
+    await mockAuthenticatedApiPage.getByTestId('editor-page').waitFor({ state: 'visible' });
+
+    // Story form has title input, rich text editor, publish toggle
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-title-input')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-publish-toggle')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-save-button')).toBeVisible();
+
+    // Story form should show "New Story" in heading
+    await expect(mockAuthenticatedApiPage.getByText('New Story')).toBeVisible();
+  });
+
+  test('renders project editor form for project content_type', async ({ mockAuthenticatedApiPage }) => {
+    await mockAuthenticatedApiPage.goto(`/editor?section_id=${TEST_SECTION_IDS.PROJECTS}`);
+    await mockAuthenticatedApiPage.getByTestId('editor-page').waitFor({ state: 'visible' });
+
+    // Project form has project-specific fields
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-title-input')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-summary-input')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-technologies-input')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-github-url-input')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-live-url-input')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-featured-toggle')).toBeVisible();
+
+    // Project form should show "New Project" in heading
+    await expect(mockAuthenticatedApiPage.getByText('New Project')).toBeVisible();
+  });
+
+  test('renders page editor form for page content_type', async ({ mockAuthenticatedApiPage }) => {
+    await mockAuthenticatedApiPage.goto(`/editor?section_id=${TEST_SECTION_IDS.ABOUT}`);
+    await mockAuthenticatedApiPage.getByTestId('editor-page').waitFor({ state: 'visible' });
+
+    // Page form has title and content
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-title-input')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-publish-toggle')).toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-save-button')).toBeVisible();
+
+    // Page form should not have project-specific fields
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-summary-input')).not.toBeVisible();
+    await expect(mockAuthenticatedApiPage.getByTestId('editor-technologies-input')).not.toBeVisible();
+  });
+
+  test('story form includes section_id in save payload', async ({ mockAuthenticatedApiPage }) => {
+    await mockAuthenticatedApiPage.goto(`/editor?section_id=${TEST_SECTION_IDS.BLOG}`);
+    await mockAuthenticatedApiPage.getByTestId('editor-page').waitFor({ state: 'visible' });
+
+    await mockAuthenticatedApiPage.getByTestId('editor-title-input').fill('Test Story With Section');
+
+    // Wait for rich text editor to load, then type content
+    const editor = mockAuthenticatedApiPage.locator('.tiptap.ProseMirror');
+    await editor.waitFor({ state: 'visible', timeout: 10000 });
+    await editor.click();
+    await mockAuthenticatedApiPage.keyboard.type('Test content');
+
+    const createPromise = mockAuthenticatedApiPage.waitForRequest(
+      (req) => req.url().includes('/api/stories') && req.method() === 'POST'
+    );
+
+    await mockAuthenticatedApiPage.getByTestId('editor-save-button').click();
+    const createRequest = await createPromise;
+    const body = createRequest.postDataJSON();
+    expect(body.section_id).toBe(TEST_SECTION_IDS.BLOG);
+    expect(body.title).toBe('Test Story With Section');
+  });
+
+  test('redirects unauthenticated users to home', async ({ mockApiPage }) => {
+    await mockApiPage.goto('/editor');
+    await mockApiPage.waitForURL('/', { timeout: 10000 });
+  });
+});

--- a/frontend/e2e/specs/smoke/smoke.spec.ts
+++ b/frontend/e2e/specs/smoke/smoke.spec.ts
@@ -63,8 +63,8 @@ test.describe('Smoke Tests', () => {
     await homePage.goto();
     await homePage.waitForLoad();
 
-    // Verify New Story link is visible
-    await expect(homePage.nav.newStoryLink).toBeVisible();
+    // Verify New content link is visible
+    await expect(homePage.nav.newContentLink).toBeVisible();
   });
 
   test('navigation links work correctly', async ({ mockApiPage }) => {

--- a/frontend/e2e/test-data.ts
+++ b/frontend/e2e/test-data.ts
@@ -352,6 +352,26 @@ export const sampleSections: TestSection[] = [
   },
 ];
 
+/**
+ * Helper to create a mock section with defaults.
+ */
+export function createTestSection(overrides: Partial<TestSection> = {}): TestSection {
+  return {
+    id: `section-${Date.now()}`,
+    title: 'Test Section',
+    slug: 'test-section',
+    parent_id: null,
+    display_type: 'feed',
+    content_type: 'story',
+    nav_visibility: 'main',
+    sort_order: 0,
+    is_published: true,
+    createdDate: FIXED_TIMESTAMP,
+    updatedDate: FIXED_TIMESTAMP,
+    ...overrides,
+  };
+}
+
 // ============================================================================
 // Engagement (Reactions & Comments)
 // ============================================================================

--- a/frontend/src/hooks/useNavSections.ts
+++ b/frontend/src/hooks/useNavSections.ts
@@ -1,9 +1,16 @@
 import { useState, useEffect } from 'react';
 import apiClient from '@/shared/lib/api-client';
-import { FALLBACK_SECTIONS, sectionsToNavItems, NavSectionItem } from '@/shared/lib/navigation';
+import { sectionsToNavItems, NavSectionItem } from '@/shared/lib/navigation';
 
 let cachedSections: NavSectionItem[] | null = null;
 let fetchPromise: Promise<NavSectionItem[]> | null = null;
+let listeners: Array<() => void> = [];
+
+export function invalidateNavCache() {
+    cachedSections = null;
+    fetchPromise = null;
+    listeners.forEach(fn => fn());
+}
 
 function fetchNavSections(): Promise<NavSectionItem[]> {
     if (cachedSections) return Promise.resolve(cachedSections);
@@ -12,10 +19,12 @@ function fetchNavSections(): Promise<NavSectionItem[]> {
     fetchPromise = apiClient.sections.navigation()
         .then(response => {
             const items = sectionsToNavItems(response.items);
-            cachedSections = items.length > 0 ? items : FALLBACK_SECTIONS;
+            cachedSections = items;
             return cachedSections;
         })
-        .catch(() => FALLBACK_SECTIONS)
+        .catch(() => {
+            return cachedSections ?? [];
+        })
         .finally(() => {
             fetchPromise = null;
         });
@@ -24,16 +33,18 @@ function fetchNavSections(): Promise<NavSectionItem[]> {
 }
 
 export function useNavSections(): NavSectionItem[] {
-    const [sections, setSections] = useState<NavSectionItem[]>(cachedSections || FALLBACK_SECTIONS);
+    const [sections, setSections] = useState<NavSectionItem[]>(cachedSections || []);
+    const [version, setVersion] = useState(0);
 
     useEffect(() => {
-        if (cachedSections) {
-            setSections(cachedSections);
-            return;
-        }
-
-        fetchNavSections().then(setSections);
+        const listener = () => setVersion(v => v + 1);
+        listeners.push(listener);
+        return () => { listeners = listeners.filter(l => l !== listener); };
     }, []);
+
+    useEffect(() => {
+        fetchNavSections().then(setSections);
+    }, [version]);
 
     return sections;
 }

--- a/frontend/src/layout/TopNav.tsx
+++ b/frontend/src/layout/TopNav.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { useNavSections } from "@/hooks/useNavSections";
 import { useActiveSection } from "@/hooks/useActiveSection";
 import { NavIcon } from "@/shared/lib/navigation";
-import { HiHome, HiUser, HiFolder, HiMail, HiPlusSm, HiViewGrid } from "react-icons/hi";
+import { HiHome, HiUser, HiFolder, HiMail, HiPlusSm, HiViewGrid, HiCog } from "react-icons/hi";
 
 const iconMap: Record<NavIcon, React.ComponentType<{ className?: string }>> = {
     home: HiHome,
@@ -22,6 +22,7 @@ export default function TopNav() {
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
     const sections = useNavSections();
     const activeSlug = useActiveSection(sections);
+    const activeSectionId = sections.find(s => s.slug === activeSlug)?.id;
 
     const toggleMobileMenu = () => {
         setMobileMenuOpen(!mobileMenuOpen);
@@ -50,10 +51,20 @@ export default function TopNav() {
                             );
                         })}
                         {session?.user?.role === 'admin' && (
-                            <Link href="/editor" className="nav__link" data-testid="nav-new-story-link">
-                                <NewStoryIcon className="nav__link-icon" aria-hidden="true" />
-                                <span>New Story</span>
-                            </Link>
+                            <>
+                                <Link
+                                    href={activeSectionId ? `/editor?section_id=${activeSectionId}` : '/editor'}
+                                    className="nav__link"
+                                    data-testid="nav-new-content-link"
+                                >
+                                    <NewStoryIcon className="nav__link-icon" aria-hidden="true" />
+                                    <span>New</span>
+                                </Link>
+                                <Link href="/admin/sections" className="nav__link" data-testid="nav-sections-link">
+                                    <HiCog className="nav__link-icon" aria-hidden="true" />
+                                    <span>Sections</span>
+                                </Link>
+                            </>
                         )}
                     </div>
 
@@ -100,15 +111,26 @@ export default function TopNav() {
                 <div className="nav__mobile-menu" data-testid="mobile-menu">
                     <div className="nav__mobile-links">
                         {session?.user?.role === 'admin' && (
-                            <Link
-                                href="/editor"
-                                className="nav__mobile-link"
-                                onClick={() => setMobileMenuOpen(false)}
-                                data-testid="mobile-nav-new-story-link"
-                            >
-                                <NewStoryIcon className="nav__link-icon" aria-hidden="true" />
-                                <span>New Story</span>
-                            </Link>
+                            <>
+                                <Link
+                                    href={activeSectionId ? `/editor?section_id=${activeSectionId}` : '/editor'}
+                                    className="nav__mobile-link"
+                                    onClick={() => setMobileMenuOpen(false)}
+                                    data-testid="mobile-nav-new-content-link"
+                                >
+                                    <NewStoryIcon className="nav__link-icon" aria-hidden="true" />
+                                    <span>New</span>
+                                </Link>
+                                <Link
+                                    href="/admin/sections"
+                                    className="nav__mobile-link"
+                                    onClick={() => setMobileMenuOpen(false)}
+                                    data-testid="mobile-nav-sections-link"
+                                >
+                                    <HiCog className="nav__link-icon" aria-hidden="true" />
+                                    <span>Sections</span>
+                                </Link>
+                            </>
                         )}
                     </div>
                 </div>

--- a/frontend/src/modules/editor/components/PageEditorForm.tsx
+++ b/frontend/src/modules/editor/components/PageEditorForm.tsx
@@ -1,0 +1,187 @@
+import dynamic from 'next/dynamic';
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
+import { Section, Page, PageType, UpdatePageRequest } from '@/shared/types/api';
+import apiClient from '@/shared/lib/api-client';
+import { ApiRequestError } from '@/shared/types/error';
+import { ErrorService } from '@/services/errorService';
+import { ErrorDisplay } from '@/components/ErrorDisplay';
+
+const RichTextEditor = dynamic(() => import('./RichTextEditor'), { ssr: false });
+
+interface PageEditorFormProps {
+  section: Section;
+}
+
+const VALID_PAGE_TYPES: PageType[] = ['about', 'contact'];
+
+export function PageEditorForm({ section }: PageEditorFormProps) {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+
+  const pageType = VALID_PAGE_TYPES.includes(section.slug as PageType)
+    ? (section.slug as PageType)
+    : null;
+
+  const [page, setPage] = useState<Partial<Page>>({ title: '', content: '', is_published: true });
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const isEditing = !!page.id;
+
+  const clearError = useCallback(() => setError(null), []);
+
+  // Fetch existing page
+  useEffect(() => {
+    if (!pageType) return;
+    let cancelled = false;
+
+    setIsLoading(true);
+    apiClient.pages.get(pageType)
+      .then(data => { if (!cancelled) setPage(data); })
+      .catch(() => { /* page doesn't exist yet — that's fine */ })
+      .finally(() => { if (!cancelled) setIsLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [pageType]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!session?.accessToken) {
+      setError('You must be logged in to save a page');
+      return;
+    }
+
+    if (!pageType) {
+      setError(`Section slug "${section.slug}" is not a valid page type. Valid types: ${VALID_PAGE_TYPES.join(', ')}`);
+      return;
+    }
+
+    if (!page.title?.trim()) {
+      setError('Page title is required');
+      return;
+    }
+
+    setError(null);
+    setIsSaving(true);
+
+    try {
+      const payload: UpdatePageRequest = {
+        title: page.title,
+        content: page.content,
+        is_published: page.is_published,
+      };
+
+      await apiClient.pages.update(pageType, payload, session.accessToken);
+      router.push(`/${section.slug}`);
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        setError(err.status === 401 ? ErrorService.handleAuthError(err) : err.getUserMessage());
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to save page');
+      }
+      setIsSaving(false);
+    }
+  }, [session, page, pageType, section.slug, router]);
+
+  // Redirect unauthenticated users
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/');
+  }, [status, router]);
+
+  if (isLoading && !isSaving) {
+    return <div>Loading...</div>;
+  }
+
+  if (!pageType) {
+    return (
+      <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+        Section &quot;{section.title}&quot; (slug: {section.slug}) is not a recognized page type. Valid page types: {VALID_PAGE_TYPES.join(', ')}.
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="section-title">
+          {isEditing ? `Edit ${section.title} Page` : `New ${section.title} Page`}
+        </h1>
+      </div>
+
+      {error && (
+        <div className="mb-4">
+          <ErrorDisplay
+            error={ErrorService.createDisplayError(error)}
+            onDismiss={clearError}
+            showDetails={true}
+          />
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-4xl mx-auto pb-24 md:pb-16">
+        <div>
+          <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Title</label>
+          <input
+            type="text"
+            id="title"
+            value={page.title || ''}
+            onChange={(e) => setPage(prev => ({ ...prev, title: e.target.value }))}
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+            placeholder="Page title"
+            required
+            disabled={isSaving}
+            data-testid="editor-title-input"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="content" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Content</label>
+          <div className="mt-1">
+            <RichTextEditor
+              content={page.content || ''}
+              onChange={(val) => setPage(prev => ({ ...prev, content: val }))}
+              actionSlot={
+                <>
+                  <div className="flex items-center">
+                    <input
+                      id="is_published"
+                      type="checkbox"
+                      checked={page.is_published || false}
+                      onChange={(e) => setPage(prev => ({ ...prev, is_published: e.target.checked }))}
+                      className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800"
+                      disabled={isSaving}
+                      data-testid="editor-publish-toggle"
+                    />
+                    <label htmlFor="is_published" className="ml-2 block text-sm text-gray-900 dark:text-gray-300">Publish</label>
+                  </div>
+                  <div className="flex gap-4">
+                    <button
+                      type="submit"
+                      className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                      disabled={isLoading || isSaving}
+                      data-testid="editor-save-button"
+                    >
+                      {isSaving ? 'Saving...' : `Save${page.is_published ? ' & Publish' : ' as Draft'}`}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => router.push(`/${section.slug}`)}
+                      className="inline-flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      disabled={isSaving}
+                      data-testid="editor-cancel-button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              }
+            />
+          </div>
+        </div>
+      </form>
+    </>
+  );
+}

--- a/frontend/src/modules/editor/components/ProjectEditorForm.tsx
+++ b/frontend/src/modules/editor/components/ProjectEditorForm.tsx
@@ -1,0 +1,233 @@
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
+import { Section } from '@/shared/types/api';
+import { useProjectEditor } from '../hooks/useProjectEditor';
+import { ErrorDisplay } from '@/components/ErrorDisplay';
+import { ErrorService } from '@/services/errorService';
+
+const RichTextEditor = dynamic(() => import('./RichTextEditor'), { ssr: false });
+
+interface ProjectEditorFormProps {
+  section: Section;
+}
+
+export function ProjectEditorForm({ section }: ProjectEditorFormProps) {
+  const router = useRouter();
+  const {
+    project,
+    error,
+    isSaving,
+    isLoading,
+    isEditing,
+    setField,
+    handleSubmit,
+    handleDelete,
+    resetForm,
+    clearError,
+  } = useProjectEditor(section.id, section.slug);
+
+  if (isLoading && !isSaving) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="section-title">
+          {isEditing ? 'Edit Project' : 'New Project'}
+        </h1>
+        {isEditing && (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={resetForm}
+              className="px-3 py-1 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors"
+              data-testid="editor-new-button"
+            >
+              New Project
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isSaving}
+              className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors disabled:opacity-50"
+              data-testid="editor-delete-button"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4">
+          <ErrorDisplay
+            error={ErrorService.createDisplayError(error)}
+            onDismiss={clearError}
+            showDetails={true}
+          />
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-4xl mx-auto pb-24 md:pb-16">
+        <div>
+          <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Title</label>
+          <input
+            type="text"
+            id="title"
+            value={project.title || ''}
+            onChange={(e) => setField('title', e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+            placeholder="Project title"
+            required
+            disabled={isSaving}
+            data-testid="editor-title-input"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="summary" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Summary</label>
+          <textarea
+            id="summary"
+            value={project.summary || ''}
+            onChange={(e) => setField('summary', e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+            placeholder="Brief project description"
+            rows={3}
+            disabled={isSaving}
+            data-testid="editor-summary-input"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="content" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Content</label>
+          <div className="mt-1">
+            <RichTextEditor
+              content={project.content || ''}
+              onChange={(val) => setField('content', val)}
+              actionSlot={
+                <>
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center">
+                      <input
+                        id="is_published"
+                        type="checkbox"
+                        checked={project.is_published || false}
+                        onChange={(e) => setField('is_published', e.target.checked)}
+                        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800"
+                        disabled={isSaving}
+                        data-testid="editor-publish-toggle"
+                      />
+                      <label htmlFor="is_published" className="ml-2 block text-sm text-gray-900 dark:text-gray-300">Publish</label>
+                    </div>
+                    <div className="flex items-center">
+                      <input
+                        id="is_featured"
+                        type="checkbox"
+                        checked={project.is_featured || false}
+                        onChange={(e) => setField('is_featured', e.target.checked)}
+                        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800"
+                        disabled={isSaving}
+                        data-testid="editor-featured-toggle"
+                      />
+                      <label htmlFor="is_featured" className="ml-2 block text-sm text-gray-900 dark:text-gray-300">Featured</label>
+                    </div>
+                  </div>
+                  <div className="flex gap-4">
+                    <button
+                      type="submit"
+                      className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                      disabled={isLoading || isSaving}
+                      data-testid="editor-save-button"
+                    >
+                      {isSaving ? 'Saving...' : `Save${project.is_published ? ' & Publish' : ' as Draft'}`}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => router.push(`/${section.slug}`)}
+                      className="inline-flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      disabled={isSaving}
+                      data-testid="editor-cancel-button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              }
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="technologies" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Technologies (comma-separated)</label>
+            <input
+              type="text"
+              id="technologies"
+              value={(project.technologies || []).join(', ')}
+              onChange={(e) => setField('technologies', e.target.value.split(',').map(s => s.trim()).filter(Boolean))}
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+              placeholder="React, TypeScript, Node.js"
+              disabled={isSaving}
+              data-testid="editor-technologies-input"
+            />
+          </div>
+          <div>
+            <label htmlFor="sort_order" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Sort Order</label>
+            <input
+              type="number"
+              id="sort_order"
+              value={project.sort_order ?? 0}
+              onChange={(e) => setField('sort_order', parseInt(e.target.value, 10) || 0)}
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+              disabled={isSaving}
+              data-testid="editor-sort-order-input"
+            />
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <label htmlFor="github_url" className="block text-sm font-medium text-gray-700 dark:text-gray-300">GitHub URL</label>
+            <input
+              type="url"
+              id="github_url"
+              value={project.github_url || ''}
+              onChange={(e) => setField('github_url', e.target.value || null)}
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+              placeholder="https://github.com/..."
+              disabled={isSaving}
+              data-testid="editor-github-url-input"
+            />
+          </div>
+          <div>
+            <label htmlFor="live_url" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Live URL</label>
+            <input
+              type="url"
+              id="live_url"
+              value={project.live_url || ''}
+              onChange={(e) => setField('live_url', e.target.value || null)}
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+              placeholder="https://..."
+              disabled={isSaving}
+              data-testid="editor-live-url-input"
+            />
+          </div>
+          <div>
+            <label htmlFor="image_url" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Image URL</label>
+            <input
+              type="url"
+              id="image_url"
+              value={project.image_url || ''}
+              onChange={(e) => setField('image_url', e.target.value || null)}
+              className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+              placeholder="https://..."
+              disabled={isSaving}
+              data-testid="editor-image-url-input"
+            />
+          </div>
+        </div>
+      </form>
+    </>
+  );
+}

--- a/frontend/src/modules/editor/components/StoryEditorForm.tsx
+++ b/frontend/src/modules/editor/components/StoryEditorForm.tsx
@@ -1,0 +1,144 @@
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
+import { Section } from '@/shared/types/api';
+import { useStoryEditor } from '../hooks/useStoryEditor';
+import { ErrorDisplay } from '@/components/ErrorDisplay';
+import { ErrorService } from '@/services/errorService';
+
+const RichTextEditor = dynamic(() => import('./RichTextEditor'), { ssr: false });
+
+interface StoryEditorFormProps {
+  section: Section;
+}
+
+export function StoryEditorForm({ section }: StoryEditorFormProps) {
+  const router = useRouter();
+  const {
+    story,
+    error,
+    isSaving,
+    isLoading,
+    isEditing,
+    setTitle,
+    setContent,
+    setPublished,
+    handleSubmit,
+    handleDelete,
+    resetForm,
+    clearError,
+  } = useStoryEditor(section.id, section.slug);
+
+  if (isLoading && !isSaving) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="section-title">
+          {isEditing ? 'Edit Story' : 'New Story'}
+        </h1>
+        {isEditing && (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={resetForm}
+              className="px-3 py-1 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors"
+              data-testid="editor-new-button"
+            >
+              New Story
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isSaving}
+              className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors disabled:opacity-50"
+              data-testid="editor-delete-button"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+
+      {error && (
+        <div className="mb-4">
+          <ErrorDisplay
+            error={ErrorService.createDisplayError(error)}
+            onDismiss={clearError}
+            showDetails={true}
+          />
+        </div>
+      )}
+
+      <form onSubmit={(e) => handleSubmit(e, true)} className="space-y-4 max-w-4xl mx-auto pb-24 md:pb-16">
+        <div>
+          <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Title
+          </label>
+          <input
+            type="text"
+            id="title"
+            value={story.title || ''}
+            onChange={(e) => setTitle(e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+            placeholder="Story title"
+            required
+            disabled={isSaving}
+            data-testid="editor-title-input"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="content" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            Content
+          </label>
+          <div className="mt-1">
+            <RichTextEditor
+              content={story.content || ''}
+              onChange={setContent}
+              actionSlot={
+                <>
+                  <div className="flex items-center">
+                    <input
+                      id="is_published"
+                      name="is_published"
+                      type="checkbox"
+                      checked={story.is_published || false}
+                      onChange={(e) => setPublished(e.target.checked)}
+                      className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800"
+                      disabled={isSaving}
+                      data-testid="editor-publish-toggle"
+                    />
+                    <label htmlFor="is_published" className="ml-2 block text-sm text-gray-900 dark:text-gray-300">
+                      Publish
+                    </label>
+                  </div>
+                  <div className="flex gap-4">
+                    <button
+                      type="submit"
+                      className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+                      disabled={isLoading || isSaving}
+                      data-testid="editor-save-button"
+                    >
+                      {isSaving ? 'Saving...' : `Save${story.is_published ? ' & Publish' : ' as Draft'}`}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => router.push(`/${section.slug}`)}
+                      className="inline-flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                      disabled={isSaving}
+                      data-testid="editor-cancel-button"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              }
+            />
+          </div>
+        </div>
+      </form>
+    </>
+  );
+}

--- a/frontend/src/modules/editor/components/index.ts
+++ b/frontend/src/modules/editor/components/index.ts
@@ -1,2 +1,5 @@
 export { default as RichTextEditor } from './RichTextEditor';
 export { VideoExtension } from './VideoExtension';
+export { StoryEditorForm } from './StoryEditorForm';
+export { ProjectEditorForm } from './ProjectEditorForm';
+export { PageEditorForm } from './PageEditorForm';

--- a/frontend/src/modules/editor/hooks/index.ts
+++ b/frontend/src/modules/editor/hooks/index.ts
@@ -3,3 +3,6 @@
  */
 export { useStoryEditor } from './useStoryEditor';
 export type { UseStoryEditorReturn } from './useStoryEditor';
+
+export { useProjectEditor } from './useProjectEditor';
+export type { UseProjectEditorReturn } from './useProjectEditor';

--- a/frontend/src/modules/editor/hooks/useProjectEditor.ts
+++ b/frontend/src/modules/editor/hooks/useProjectEditor.ts
@@ -1,0 +1,166 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
+import { Project, CreateProjectRequest } from '@/shared/types/api';
+import apiClient from '@/shared/lib/api-client';
+import { ApiRequestError } from '@/shared/types/error';
+import { ErrorService } from '@/services/errorService';
+
+const EMPTY_PROJECT: Partial<Project> = {
+  title: '',
+  summary: '',
+  content: '',
+  technologies: [],
+  github_url: null,
+  live_url: null,
+  image_url: null,
+  is_published: true,
+  is_featured: false,
+  sort_order: 0,
+};
+
+export interface UseProjectEditorReturn {
+  project: Partial<Project>;
+  error: string | null;
+  isSaving: boolean;
+  isLoading: boolean;
+  isEditing: boolean;
+  setField: <K extends keyof Project>(key: K, value: Project[K]) => void;
+  handleSubmit: (e: React.FormEvent) => Promise<void>;
+  handleDelete: () => Promise<void>;
+  resetForm: () => void;
+  clearError: () => void;
+}
+
+export function useProjectEditor(sectionId?: string, sectionSlug?: string): UseProjectEditorReturn {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  const { id } = router.query;
+  const projectId = typeof id === 'string' ? id : undefined;
+
+  const [project, setProject] = useState<Partial<Project>>(EMPTY_PROJECT);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const accessToken = session?.accessToken;
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const resetForm = useCallback(() => {
+    setProject(EMPTY_PROJECT);
+    setError(null);
+    const query = sectionId ? `?section_id=${sectionId}` : '';
+    router.push(`/editor${query}`, undefined, { shallow: true });
+  }, [router, sectionId]);
+
+  const setField = useCallback(<K extends keyof Project>(key: K, value: Project[K]) => {
+    setProject(prev => ({ ...prev, [key]: value }));
+  }, []);
+
+  // Fetch existing project for editing
+  useEffect(() => {
+    if (!projectId || !accessToken) return;
+    let cancelled = false;
+
+    async function fetchProject() {
+      setIsLoading(true);
+      try {
+        const data = await apiClient.projects.getById(projectId!, accessToken!);
+        if (!cancelled) setProject(data);
+      } catch {
+        if (!cancelled) setError('Failed to load project');
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    fetchProject();
+    return () => { cancelled = true; };
+  }, [projectId, accessToken]);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!session?.accessToken) {
+      setError('You must be logged in to save a project');
+      return;
+    }
+
+    if (!project.title?.trim()) {
+      setError('Project title is required');
+      return;
+    }
+
+    setError(null);
+    setIsSaving(true);
+
+    try {
+      const payload = {
+        title: project.title,
+        summary: project.summary || '',
+        content: project.content || '',
+        technologies: project.technologies || [],
+        github_url: project.github_url || undefined,
+        live_url: project.live_url || undefined,
+        image_url: project.image_url || undefined,
+        is_published: project.is_published,
+        is_featured: project.is_featured,
+        sort_order: project.sort_order,
+        section_id: project.section_id || sectionId,
+      };
+
+      if (project.id) {
+        await apiClient.projects.update(project.id, payload, session.accessToken);
+      } else {
+        await apiClient.projects.create(payload as CreateProjectRequest, session.accessToken);
+      }
+
+      router.push(sectionSlug ? `/${sectionSlug}` : '/');
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        setError(err.status === 401 ? ErrorService.handleAuthError(err) : err.getUserMessage());
+      } else {
+        setError(err instanceof Error ? err.message : 'Failed to save project');
+      }
+      setIsSaving(false);
+    }
+  }, [session, project, sectionId, sectionSlug, router]);
+
+  const handleDelete = useCallback(async () => {
+    if (!project.id || !session?.accessToken) {
+      setError('Cannot delete project: missing ID or not logged in');
+      return;
+    }
+
+    if (!confirm(`Delete "${project.title}"? This cannot be undone.`)) return;
+
+    try {
+      await apiClient.projects.delete(project.id, session.accessToken);
+      router.push(sectionSlug ? `/${sectionSlug}` : '/');
+    } catch (err) {
+      if (err instanceof ApiRequestError) {
+        setError(err.getUserMessage());
+      } else {
+        setError('Failed to delete project');
+      }
+    }
+  }, [project.id, project.title, session, sectionSlug, router]);
+
+  // Redirect unauthenticated users
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/');
+  }, [status, router]);
+
+  return {
+    project,
+    error,
+    isSaving,
+    isLoading: isLoading || status === 'loading',
+    isEditing: !!project.id,
+    setField,
+    handleSubmit,
+    handleDelete,
+    resetForm,
+    clearError,
+  };
+}

--- a/frontend/src/modules/editor/hooks/useStoryEditor.ts
+++ b/frontend/src/modules/editor/hooks/useStoryEditor.ts
@@ -39,7 +39,7 @@ export interface UseStoryEditorReturn {
  * - Auto-save on session expiry
  * - Fetching existing stories for editing
  */
-export function useStoryEditor(): UseStoryEditorReturn {
+export function useStoryEditor(sectionId?: string, sectionSlug?: string): UseStoryEditorReturn {
   const router = useRouter();
   const { data: session, status } = useSession();
   const { id } = router.query;
@@ -59,8 +59,9 @@ export function useStoryEditor(): UseStoryEditorReturn {
   const resetForm = useCallback(() => {
     setStory(EMPTY_STORY);
     setError(null);
-    router.push('/editor', undefined, { shallow: true });
-  }, [router]);
+    const query = sectionId ? `?section_id=${sectionId}` : '';
+    router.push(`/editor${query}`, undefined, { shallow: true });
+  }, [router, sectionId]);
 
   // Field updaters
   const setTitle = useCallback((title: string) => {
@@ -96,6 +97,7 @@ export function useStoryEditor(): UseStoryEditorReturn {
       const storyToSave = {
         ...story,
         is_published: shouldPublish ? story.is_published : false,
+        ...(sectionId && !story.section_id ? { section_id: sectionId } : {}),
       };
 
       logger.info('Saving story', { id: story.id, title: story.title });
@@ -106,13 +108,13 @@ export function useStoryEditor(): UseStoryEditorReturn {
       }
 
       logger.info('Story saved', { id: result.id, title: result.title });
-      router.push('/');
+      router.push(sectionSlug ? `/${sectionSlug}` : '/');
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error occurred';
       setError(`Error: ${message}`);
       setIsSaving(false);
     }
-  }, [session, story, saveStory, router]);
+  }, [session, story, sectionId, sectionSlug, saveStory, router]);
 
   // Delete handler
   const handleDelete = useCallback(async () => {
@@ -127,9 +129,9 @@ export function useStoryEditor(): UseStoryEditorReturn {
 
     const success = await deleteStory(story.id);
     if (success) {
-      router.push('/');
+      router.push(sectionSlug ? `/${sectionSlug}` : '/');
     }
-  }, [story.id, story.title, session, deleteStory, router]);
+  }, [story.id, story.title, session, sectionSlug, deleteStory, router]);
 
   // Sync fetched story to form state
   useEffect(() => {
@@ -146,9 +148,10 @@ export function useStoryEditor(): UseStoryEditorReturn {
     }
   }, [fetchError, storyId]);
 
-  // Reset form when navigating to /editor without ID
+  // Reset form when navigating to /editor without story ID
   useEffect(() => {
-    if (!storyId && (Object.keys(router.query).length > 0 || story.id)) {
+    const queryKeys = Object.keys(router.query).filter(k => k !== 'section_id');
+    if (!storyId && (queryKeys.length > 0 || story.id)) {
       resetForm();
     }
   }, [storyId, router.query, story.id, resetForm]);

--- a/frontend/src/modules/sections/hooks/index.ts
+++ b/frontend/src/modules/sections/hooks/index.ts
@@ -1,0 +1,5 @@
+export { useFetchSections } from './useFetchSections';
+export type { UseFetchSectionsReturn } from './useFetchSections';
+
+export { useSectionMutations } from './useSectionMutations';
+export type { UseSectionMutationsReturn } from './useSectionMutations';

--- a/frontend/src/modules/sections/hooks/useFetchSections.ts
+++ b/frontend/src/modules/sections/hooks/useFetchSections.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import apiClient from '@/shared/lib/api-client';
+import { Section } from '@/shared/types/api';
+
+export interface UseFetchSectionsReturn {
+  sections: Section[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+  clearError: () => void;
+}
+
+export function useFetchSections(): UseFetchSectionsReturn {
+  const { data: session } = useSession();
+  const [sections, setSections] = useState<Section[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [fetchCount, setFetchCount] = useState(0);
+
+  const refetch = useCallback(() => setFetchCount(c => c + 1), []);
+  const clearError = useCallback(() => setError(null), []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchSections() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await apiClient.sections.list(session?.accessToken);
+        if (!cancelled) {
+          setSections(response.items);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to fetch sections');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchSections();
+    return () => { cancelled = true; };
+  }, [session?.accessToken, fetchCount]);
+
+  return { sections, loading, error, refetch, clearError };
+}

--- a/frontend/src/modules/sections/hooks/useSectionMutations.ts
+++ b/frontend/src/modules/sections/hooks/useSectionMutations.ts
@@ -1,0 +1,93 @@
+import { useState, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import apiClient from '@/shared/lib/api-client';
+import { ApiRequestError } from '@/shared/types/error';
+import { Section, CreateSectionRequest, UpdateSectionRequest } from '@/shared/types/api';
+import { ErrorService } from '@/services/errorService';
+
+export interface UseSectionMutationsReturn {
+  loading: boolean;
+  error: string | null;
+  createSection: (data: CreateSectionRequest) => Promise<Section | null>;
+  updateSection: (id: string, data: UpdateSectionRequest) => Promise<Section | null>;
+  deleteSection: (id: string) => Promise<boolean>;
+  clearError: () => void;
+}
+
+export function useSectionMutations(): UseSectionMutationsReturn {
+  const { data: session } = useSession();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const clearError = useCallback(() => setError(null), []);
+
+  const handleApiError = useCallback((err: unknown, fallbackMessage: string) => {
+    if (err instanceof ApiRequestError) {
+      setError(err.status === 401 ? ErrorService.handleAuthError(err) : err.getUserMessage());
+    } else {
+      setError(fallbackMessage);
+    }
+  }, []);
+
+  const createSection = useCallback(async (data: CreateSectionRequest): Promise<Section | null> => {
+    if (!session?.accessToken) {
+      setError('You must be logged in to create a section');
+      return null;
+    }
+
+    setLoading(true);
+    clearError();
+
+    try {
+      const result = await apiClient.sections.create(data, session.accessToken);
+      return result;
+    } catch (err) {
+      handleApiError(err, 'Failed to create section');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.accessToken, clearError, handleApiError]);
+
+  const updateSection = useCallback(async (id: string, data: UpdateSectionRequest): Promise<Section | null> => {
+    if (!session?.accessToken) {
+      setError('You must be logged in to update a section');
+      return null;
+    }
+
+    setLoading(true);
+    clearError();
+
+    try {
+      const result = await apiClient.sections.update(id, data, session.accessToken);
+      return result;
+    } catch (err) {
+      handleApiError(err, 'Failed to update section');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.accessToken, clearError, handleApiError]);
+
+  const deleteSection = useCallback(async (id: string): Promise<boolean> => {
+    if (!session?.accessToken) {
+      setError('You must be logged in to delete a section');
+      return false;
+    }
+
+    setLoading(true);
+    clearError();
+
+    try {
+      await apiClient.sections.delete(id, session.accessToken);
+      return true;
+    } catch (err) {
+      handleApiError(err, 'Failed to delete section');
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [session?.accessToken, clearError, handleApiError]);
+
+  return { loading, error, createSection, updateSection, deleteSection, clearError };
+}

--- a/frontend/src/modules/sections/index.ts
+++ b/frontend/src/modules/sections/index.ts
@@ -1,0 +1,1 @@
+export * from './hooks';

--- a/frontend/src/pages/[...slugPath].tsx
+++ b/frontend/src/pages/[...slugPath].tsx
@@ -91,8 +91,8 @@ function SectionListView({ section, initialListData }: { section: Section; initi
             router.push('/api/auth/signin');
             return;
         }
-        router.push({ pathname: '/editor', query: { id: story.id } });
-    }, [session, router]);
+        router.push({ pathname: '/editor', query: { id: story.id, section_id: section.id } });
+    }, [session, router, section.id]);
 
     const handleDelete = useCallback(async (story: Story) => {
         if (!session) {

--- a/frontend/src/pages/admin/sections.tsx
+++ b/frontend/src/pages/admin/sections.tsx
@@ -1,0 +1,306 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
+import { useFetchSections, useSectionMutations } from '@/modules/sections';
+import { invalidateNavCache } from '@/hooks/useNavSections';
+import { Section, CreateSectionRequest, DisplayType, SectionContentType, NavVisibility } from '@/shared/types/api';
+import { ErrorDisplay } from '@/components/ErrorDisplay';
+import { ErrorService } from '@/services/errorService';
+
+const DISPLAY_TYPES: DisplayType[] = ['feed', 'card-grid', 'static-page', 'gallery'];
+const CONTENT_TYPES: SectionContentType[] = ['story', 'project', 'page', 'image'];
+const NAV_VISIBILITIES: NavVisibility[] = ['main', 'secondary', 'hidden'];
+
+export default function AdminSectionsPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const { sections, loading, error: fetchError, refetch, clearError: clearFetchError } = useFetchSections();
+  const { createSection, updateSection, deleteSection, loading: mutating, error: mutateError, clearError: clearMutateError } = useSectionMutations();
+
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const error = fetchError || mutateError;
+  const clearError = useCallback(() => { clearFetchError(); clearMutateError(); }, [clearFetchError, clearMutateError]);
+
+  // Auth guard — redirect in useEffect, not during render
+  useEffect(() => {
+    if (status !== 'loading' && (!session || session.user?.role !== 'admin')) {
+      router.replace('/');
+    }
+  }, [status, session, router]);
+
+  if (status === 'loading' || !session || session.user?.role !== 'admin') {
+    return null;
+  }
+
+  const handleCreate = async (data: CreateSectionRequest) => {
+    const result = await createSection(data);
+    if (result) {
+      setShowCreateForm(false);
+      invalidateNavCache();
+      refetch();
+    }
+  };
+
+  const handleUpdate = async (id: string, data: Partial<CreateSectionRequest>) => {
+    const result = await updateSection(id, data);
+    if (result) {
+      setEditingId(null);
+      invalidateNavCache();
+      refetch();
+    }
+  };
+
+  const handleDelete = async (section: Section) => {
+    if (!confirm(`Delete section "${section.title}"? This cannot be undone.`)) return;
+    const success = await deleteSection(section.id);
+    if (success) {
+      invalidateNavCache();
+      refetch();
+    }
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8" data-testid="admin-sections-page">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="section-title">Manage Sections</h1>
+        <button
+          type="button"
+          onClick={() => { setShowCreateForm(!showCreateForm); setEditingId(null); }}
+          className="btn btn--primary"
+          data-testid="create-section-button"
+        >
+          {showCreateForm ? 'Cancel' : 'New Section'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4">
+          <ErrorDisplay
+            error={ErrorService.createDisplayError(error)}
+            onDismiss={clearError}
+          />
+        </div>
+      )}
+
+      {showCreateForm && (
+        <SectionCreateForm onSubmit={handleCreate} disabled={mutating} />
+      )}
+
+      {loading ? (
+        <div>Loading sections...</div>
+      ) : (
+        <div className="space-y-2" data-testid="sections-list">
+          {sections.map(section => (
+            editingId === section.id ? (
+              <SectionEditForm
+                key={section.id}
+                section={section}
+                onSubmit={(data) => handleUpdate(section.id, data)}
+                onCancel={() => setEditingId(null)}
+                disabled={mutating}
+              />
+            ) : (
+              <SectionRow
+                key={section.id}
+                section={section}
+                onEdit={() => { setEditingId(section.id); setShowCreateForm(false); }}
+                onDelete={() => handleDelete(section)}
+                onAddContent={() => router.push(`/editor?section_id=${section.id}`)}
+                disabled={mutating}
+              />
+            )
+          ))}
+          {sections.length === 0 && (
+            <p className="text-gray-500 dark:text-gray-400">No sections found.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SectionCreateForm({
+  onSubmit,
+  disabled,
+}: {
+  onSubmit: (data: CreateSectionRequest) => void;
+  disabled: boolean;
+}) {
+  const [title, setTitle] = useState('');
+  const [displayType, setDisplayType] = useState<DisplayType>('feed');
+  const [contentType, setContentType] = useState<SectionContentType>('story');
+  const [navVisibility, setNavVisibility] = useState<NavVisibility>('main');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    onSubmit({ title: title.trim(), display_type: displayType, content_type: contentType, nav_visibility: navVisibility });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="mb-6 p-4 border border-gray-200 dark:border-gray-700 rounded-lg space-y-3" data-testid="section-create-form">
+      <div>
+        <label htmlFor="new-section-title" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Title</label>
+        <input
+          id="new-section-title"
+          type="text"
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+          required
+          disabled={disabled}
+          data-testid="section-title-input"
+        />
+      </div>
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <label htmlFor="new-section-display" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Display Type</label>
+          <select id="new-section-display" value={displayType} onChange={e => setDisplayType(e.target.value as DisplayType)} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm dark:bg-gray-800 dark:text-white" disabled={disabled} data-testid="section-display-type-select">
+            {DISPLAY_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="new-section-content" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Content Type</label>
+          <select id="new-section-content" value={contentType} onChange={e => setContentType(e.target.value as SectionContentType)} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm dark:bg-gray-800 dark:text-white" disabled={disabled} data-testid="section-content-type-select">
+            {CONTENT_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="new-section-nav" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Nav Visibility</label>
+          <select id="new-section-nav" value={navVisibility} onChange={e => setNavVisibility(e.target.value as NavVisibility)} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm dark:bg-gray-800 dark:text-white" disabled={disabled} data-testid="section-nav-visibility-select">
+            {NAV_VISIBILITIES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </div>
+      </div>
+      <button type="submit" disabled={disabled} className="btn btn--primary" data-testid="section-create-submit">
+        Create Section
+      </button>
+    </form>
+  );
+}
+
+function SectionRow({
+  section,
+  onEdit,
+  onDelete,
+  onAddContent,
+  disabled,
+}: {
+  section: Section;
+  onEdit: () => void;
+  onDelete: () => void;
+  onAddContent: () => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between p-3 border border-gray-200 dark:border-gray-700 rounded-lg" data-testid={`section-row-${section.id}`}>
+      <div className="flex-1">
+        <span className="font-medium text-text-primary">{section.title}</span>
+        <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">/{section.slug}</span>
+        <span className="ml-2 text-xs px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">{section.display_type}</span>
+        <span className="ml-1 text-xs px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">{section.content_type}</span>
+        <span className="ml-1 text-xs px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">{section.nav_visibility}</span>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={onAddContent}
+          className="px-3 py-1 text-sm bg-green-600 text-white rounded hover:bg-green-700 transition-colors"
+          disabled={disabled}
+          data-testid={`section-add-content-${section.id}`}
+        >
+          Add Content
+        </button>
+        <button
+          type="button"
+          onClick={onEdit}
+          className="px-3 py-1 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors"
+          disabled={disabled}
+          data-testid={`section-edit-${section.id}`}
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors"
+          disabled={disabled}
+          data-testid={`section-delete-${section.id}`}
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SectionEditForm({
+  section,
+  onSubmit,
+  onCancel,
+  disabled,
+}: {
+  section: Section;
+  onSubmit: (data: Partial<CreateSectionRequest>) => void;
+  onCancel: () => void;
+  disabled: boolean;
+}) {
+  const [title, setTitle] = useState(section.title);
+  const [displayType, setDisplayType] = useState<DisplayType>(section.display_type);
+  const [contentType, setContentType] = useState<SectionContentType>(section.content_type);
+  const [navVisibility, setNavVisibility] = useState<NavVisibility>(section.nav_visibility);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+    onSubmit({ title: title.trim(), display_type: displayType, content_type: contentType, nav_visibility: navVisibility });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="p-3 border-2 border-indigo-500 rounded-lg space-y-3" data-testid={`section-edit-form-${section.id}`}>
+      <div className="grid grid-cols-4 gap-3">
+        <div>
+          <label htmlFor={`edit-title-${section.id}`} className="block text-sm font-medium text-gray-700 dark:text-gray-300">Title</label>
+          <input
+            id={`edit-title-${section.id}`}
+            type="text"
+            value={title}
+            onChange={e => setTitle(e.target.value)}
+            className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
+            required
+            disabled={disabled}
+            data-testid={`section-edit-title-${section.id}`}
+          />
+        </div>
+        <div>
+          <label htmlFor={`edit-display-${section.id}`} className="block text-sm font-medium text-gray-700 dark:text-gray-300">Display Type</label>
+          <select id={`edit-display-${section.id}`} value={displayType} onChange={e => setDisplayType(e.target.value as DisplayType)} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm dark:bg-gray-800 dark:text-white" disabled={disabled}>
+            {DISPLAY_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </div>
+        <div>
+          <label htmlFor={`edit-content-${section.id}`} className="block text-sm font-medium text-gray-700 dark:text-gray-300">Content Type</label>
+          <select id={`edit-content-${section.id}`} value={contentType} onChange={e => setContentType(e.target.value as SectionContentType)} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm dark:bg-gray-800 dark:text-white" disabled={disabled}>
+            {CONTENT_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </div>
+        <div>
+          <label htmlFor={`edit-nav-${section.id}`} className="block text-sm font-medium text-gray-700 dark:text-gray-300">Nav Visibility</label>
+          <select id={`edit-nav-${section.id}`} value={navVisibility} onChange={e => setNavVisibility(e.target.value as NavVisibility)} className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm dark:bg-gray-800 dark:text-white" disabled={disabled}>
+            {NAV_VISIBILITIES.map(t => <option key={t} value={t}>{t}</option>)}
+          </select>
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button type="submit" disabled={disabled} className="btn btn--primary" data-testid={`section-edit-submit-${section.id}`}>
+          Save
+        </button>
+        <button type="button" onClick={onCancel} className="btn btn--secondary" data-testid={`section-edit-cancel-${section.id}`}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/pages/api/sections/[id].ts
+++ b/frontend/src/pages/api/sections/[id].ts
@@ -1,0 +1,92 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const API_BASE_URL = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL;
+
+    if (!API_BASE_URL) {
+        return res.status(500).json({
+            detail: 'Backend URL not configured. Set BACKEND_URL or NEXT_PUBLIC_API_URL',
+            error: 'Configuration error'
+        });
+    }
+
+    const { id } = req.query;
+
+    if (!id || typeof id !== 'string') {
+        return res.status(400).json({ detail: 'Section ID is required', error: 'Invalid request' });
+    }
+
+    try {
+        const token = await getToken({ req });
+        const headers: HeadersInit = {
+            'Content-Type': 'application/json',
+        };
+
+        if (token?.accessToken) {
+            headers.Authorization = `Bearer ${token.accessToken}`;
+        }
+
+        const apiUrl = `${API_BASE_URL}/sections/${id}`;
+
+        if (req.method === 'GET') {
+            const response = await fetch(apiUrl, { headers });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
+                return res.status(response.status).json(errorData);
+            }
+
+            const data = await response.json();
+            return res.status(200).json(data);
+        } else if (req.method === 'PUT') {
+            if (!token?.accessToken) {
+                return res.status(401).json({ detail: 'Authentication required', error: 'Unauthorized' });
+            }
+
+            const response = await fetch(apiUrl, {
+                method: 'PUT',
+                headers,
+                body: JSON.stringify(req.body),
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
+                return res.status(response.status).json({
+                    detail: errorData.detail || `Error: ${response.statusText}`,
+                    status: response.status
+                });
+            }
+
+            const data = await response.json();
+            return res.status(200).json(data);
+        } else if (req.method === 'DELETE') {
+            if (!token?.accessToken) {
+                return res.status(401).json({ detail: 'Authentication required', error: 'Unauthorized' });
+            }
+
+            const response = await fetch(apiUrl, {
+                method: 'DELETE',
+                headers,
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
+                return res.status(response.status).json({
+                    detail: errorData.detail || `Error: ${response.statusText}`,
+                    status: response.status
+                });
+            }
+
+            return res.status(204).end();
+        } else {
+            return res.status(405).json({ detail: 'Method not allowed', error: 'Invalid request' });
+        }
+    } catch (error) {
+        console.error(`Error in /api/sections/${id}:`, error);
+        return res.status(500).json({
+            detail: error instanceof Error ? error.message : 'Internal server error',
+            error: 'Failed to process request'
+        });
+    }
+}

--- a/frontend/src/pages/api/sections/index.ts
+++ b/frontend/src/pages/api/sections/index.ts
@@ -1,0 +1,72 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+    const API_BASE_URL = process.env.BACKEND_URL || process.env.NEXT_PUBLIC_API_URL;
+
+    if (!API_BASE_URL) {
+        return res.status(500).json({
+            detail: 'Backend URL not configured. Set BACKEND_URL or NEXT_PUBLIC_API_URL',
+            error: 'Configuration error'
+        });
+    }
+
+    try {
+        const token = await getToken({ req });
+        const headers: HeadersInit = {
+            'Content-Type': 'application/json',
+        };
+
+        if (token?.accessToken) {
+            headers.Authorization = `Bearer ${token.accessToken}`;
+        }
+
+        if (req.method === 'GET') {
+            const url = new URL(`${API_BASE_URL}/sections`);
+            for (const [key, value] of Object.entries(req.query)) {
+                if (typeof value === 'string') {
+                    url.searchParams.set(key, value);
+                }
+            }
+
+            const response = await fetch(url.toString(), { headers });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
+                return res.status(response.status).json(errorData);
+            }
+
+            const data = await response.json();
+            return res.status(200).json(data);
+        } else if (req.method === 'POST') {
+            if (!token?.accessToken) {
+                return res.status(401).json({ detail: 'Authentication required', error: 'Unauthorized' });
+            }
+
+            const response = await fetch(`${API_BASE_URL}/sections`, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(req.body),
+            });
+
+            if (!response.ok) {
+                const errorData = await response.json().catch(() => ({ detail: 'Unknown error' }));
+                return res.status(response.status).json({
+                    detail: errorData.detail || `Error: ${response.statusText}`,
+                    status: response.status
+                });
+            }
+
+            const data = await response.json();
+            return res.status(201).json(data);
+        } else {
+            return res.status(405).json({ detail: 'Method not allowed', error: 'Invalid request' });
+        }
+    } catch (error) {
+        console.error('Error in /api/sections:', error);
+        return res.status(500).json({
+            detail: error instanceof Error ? error.message : 'Internal server error',
+            error: 'Failed to process request'
+        });
+    }
+}

--- a/frontend/src/pages/editor.tsx
+++ b/frontend/src/pages/editor.tsx
@@ -1,249 +1,156 @@
-import dynamic from 'next/dynamic';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { useStoryEditor } from '@/modules/editor';
-import { ErrorDisplay } from '@/components/ErrorDisplay';
-import { ErrorService } from '@/services/errorService';
+import { useSession } from 'next-auth/react';
+import { Section } from '@/shared/types/api';
+import apiClient from '@/shared/lib/api-client';
+import { StoryEditorForm, ProjectEditorForm, PageEditorForm } from '@/modules/editor/components';
+import { useFetchSections } from '@/modules/sections';
 
-const RichTextEditor = dynamic(() => import('@/modules/editor/components/RichTextEditor'), { ssr: false });
-
-/**
- * Story editor page for creating and editing stories.
- */
 export default function EditorPage() {
   const router = useRouter();
-  const {
-    story,
-    error,
-    isSaving,
-    isLoading,
-    isEditing,
-    setTitle,
-    setContent,
-    setPublished,
-    handleSubmit,
-    handleDelete,
-    resetForm,
-    clearError,
-  } = useStoryEditor();
+  const { data: session, status } = useSession();
+  const { section_id, id } = router.query;
+  const sectionId = typeof section_id === 'string' ? section_id : undefined;
+  const editId = typeof id === 'string' ? id : undefined;
 
-  if (isLoading && !isSaving) {
+  const [section, setSection] = useState<Section | null>(null);
+  const [loadingSection, setLoadingSection] = useState(false);
+  const [sectionError, setSectionError] = useState<string | null>(null);
+
+  // Redirect unauthenticated users
+  useEffect(() => {
+    if (status === 'unauthenticated') router.push('/');
+  }, [status, router]);
+
+  // Resolve section_id from content item when editing without section_id
+  const accessToken = session?.accessToken;
+  useEffect(() => {
+    if (sectionId || !editId || !accessToken) return;
+
+    let cancelled = false;
+    setLoadingSection(true);
+
+    // Try fetching as story first (most common), then project
+    apiClient.stories.getById(editId, accessToken)
+      .then(story => {
+        if (cancelled) return;
+        if (story.section_id) {
+          router.replace({ pathname: '/editor', query: { id: editId, section_id: story.section_id } }, undefined, { shallow: true });
+        } else {
+          setSectionError('This content has no section assigned. Edit it from its section page instead.');
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Try as project by ID
+        return apiClient.projects.getById(editId, accessToken).then(project => {
+          if (cancelled) return;
+          if (project.section_id) {
+            router.replace({ pathname: '/editor', query: { id: editId, section_id: project.section_id } }, undefined, { shallow: true });
+          } else {
+            setSectionError('This content has no section assigned. Edit it from its section page instead.');
+          }
+        });
+      })
+      .catch(() => {
+        if (!cancelled) setSectionError('Content not found.');
+      })
+      .finally(() => { if (!cancelled) setLoadingSection(false); });
+
+    return () => { cancelled = true; };
+  }, [editId, sectionId, accessToken, router]);
+
+  // Fetch section when section_id is provided
+  useEffect(() => {
+    if (!sectionId) {
+      setSection(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingSection(true);
+    setSectionError(null);
+
+    apiClient.sections.getById(sectionId, session?.accessToken)
+      .then(data => { if (!cancelled) setSection(data); })
+      .catch(() => { if (!cancelled) setSectionError('Failed to load section'); })
+      .finally(() => { if (!cancelled) setLoadingSection(false); });
+
+    return () => { cancelled = true; };
+  }, [sectionId, session?.accessToken]);
+
+  if (status === 'loading' || status === 'unauthenticated' || loadingSection) {
     return <div>Loading...</div>;
   }
 
+  if (sectionError) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <p className="text-red-600">{sectionError}</p>
+      </div>
+    );
+  }
+
+  // No section selected — show section picker
+  if (!section) {
+    return (
+      <div className="container mx-auto px-4 py-8" data-testid="editor-page">
+        <SectionPicker onSelect={(s) => router.push(`/editor?section_id=${s.id}`)} />
+      </div>
+    );
+  }
+
+  // Render the correct form based on content_type
   return (
     <div className="container mx-auto px-4 py-8" data-testid="editor-page">
-      <EditorHeader
-        isEditing={isEditing}
-        onNewStory={resetForm}
-        onDelete={handleDelete}
-        isDeleting={isSaving}
-      />
-
-      {error && (
-        <div className="mb-4">
-          <ErrorDisplay
-            error={ErrorService.createDisplayError(error)}
-            onDismiss={clearError}
-            showDetails={true}
-          />
-        </div>
-      )}
-
-      <form onSubmit={(e) => handleSubmit(e, true)} className="space-y-4 max-w-4xl mx-auto pb-24 md:pb-16">
-        <TitleInput
-          value={story.title || ''}
-          onChange={setTitle}
-          disabled={isSaving}
-        />
-
-        <ContentEditor
-          content={story.content || ''}
-          onChange={setContent}
-          actionSlot={
-            <>
-              <PublishToggle
-                checked={story.is_published || false}
-                onChange={setPublished}
-                disabled={isSaving}
-              />
-              <FormActions
-                isLoading={isLoading}
-                isSaving={isSaving}
-                isPublished={story.is_published || false}
-                onCancel={() => router.push('/')}
-              />
-            </>
-          }
-        />
-      </form>
-    </div>
-  );
-}
-
-/**
- * Editor page header with title and action buttons.
- */
-function EditorHeader({
-  isEditing,
-  onNewStory,
-  onDelete,
-  isDeleting,
-}: {
-  isEditing: boolean;
-  onNewStory: () => void;
-  onDelete: () => void;
-  isDeleting: boolean;
-}) {
-  return (
-    <div className="flex justify-between items-center mb-4">
-      <h1 className="section-title">
-        {isEditing ? 'Edit Story' : 'New Story'}
-      </h1>
-      {isEditing && (
-        <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={onNewStory}
-            className="px-3 py-1 text-sm bg-indigo-600 text-white rounded hover:bg-indigo-700 transition-colors"
-            data-testid="editor-new-button"
-          >
-            New Story
-          </button>
-          <button
-            type="button"
-            onClick={onDelete}
-            disabled={isDeleting}
-            className="px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 transition-colors disabled:opacity-50"
-            data-testid="editor-delete-button"
-          >
-            Delete
-          </button>
+      {section.content_type === 'story' && <StoryEditorForm section={section} />}
+      {section.content_type === 'project' && <ProjectEditorForm section={section} />}
+      {section.content_type === 'page' && <PageEditorForm section={section} />}
+      {!['story', 'project', 'page'].includes(section.content_type) && (
+        <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+          Content type &quot;{section.content_type}&quot; does not have an editor form yet.
         </div>
       )}
     </div>
   );
 }
 
-/**
- * Title input field.
- */
-function TitleInput({
-  value,
-  onChange,
-  disabled,
-}: {
-  value: string;
-  onChange: (value: string) => void;
-  disabled: boolean;
-}) {
-  return (
-    <div>
-      <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-        Title
-      </label>
-      <input
-        type="text"
-        id="title"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:bg-gray-800 dark:text-white"
-        placeholder="Story title"
-        required
-        disabled={disabled}
-        data-testid="editor-title-input"
-      />
-    </div>
-  );
-}
+function SectionPicker({ onSelect }: { onSelect: (section: Section) => void }) {
+  const { sections, loading } = useFetchSections();
 
-/**
- * Rich text content editor wrapper.
- */
-function ContentEditor({
-  content,
-  onChange,
-  actionSlot,
-}: {
-  content: string;
-  onChange: (content: string) => void;
-  actionSlot?: React.ReactNode;
-}) {
+  // Filter to sections with editable content types
+  const editableSections = sections.filter(s =>
+    ['story', 'project', 'page'].includes(s.content_type)
+  );
+
+  if (loading) return <div>Loading sections...</div>;
+
   return (
-    <div>
-      <label htmlFor="content" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-        Content
-      </label>
-      <div className="mt-1">
-        <RichTextEditor content={content} onChange={onChange} actionSlot={actionSlot} />
+    <div data-testid="section-picker">
+      <h1 className="section-title mb-4">Select a Section</h1>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">Choose which section to create content for.</p>
+      <div className="grid gap-3 max-w-2xl">
+        {editableSections.map(section => (
+          <button
+            key={section.id}
+            type="button"
+            onClick={() => onSelect(section)}
+            className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-700 rounded-lg hover:border-indigo-500 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors text-left"
+            data-testid={`section-picker-${section.slug}`}
+          >
+            <div>
+              <span className="font-medium text-text-primary">{section.title}</span>
+              <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">({section.content_type})</span>
+            </div>
+            <span className="text-xs px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+              {section.display_type}
+            </span>
+          </button>
+        ))}
+        {editableSections.length === 0 && (
+          <p className="text-gray-500 dark:text-gray-400">No editable sections found.</p>
+        )}
       </div>
-    </div>
-  );
-}
-
-/**
- * Publish toggle checkbox.
- */
-function PublishToggle({
-  checked,
-  onChange,
-  disabled,
-}: {
-  checked: boolean;
-  onChange: (checked: boolean) => void;
-  disabled: boolean;
-}) {
-  return (
-    <div className="flex items-center">
-      <input
-        id="is_published"
-        name="is_published"
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-800"
-        disabled={disabled}
-        data-testid="editor-publish-toggle"
-      />
-      <label htmlFor="is_published" className="ml-2 block text-sm text-gray-900 dark:text-gray-300">
-        Publish
-      </label>
-    </div>
-  );
-}
-
-/**
- * Form action buttons (Save/Cancel).
- */
-function FormActions({
-  isLoading,
-  isSaving,
-  isPublished,
-  onCancel,
-}: {
-  isLoading: boolean;
-  isSaving: boolean;
-  isPublished: boolean;
-  onCancel: () => void;
-}) {
-  return (
-    <div className="flex gap-4">
-      <button
-        type="submit"
-        className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
-        disabled={isLoading || isSaving}
-        data-testid="editor-save-button"
-      >
-        {isSaving ? 'Saving...' : `Save${isPublished ? ' & Publish' : ' as Draft'}`}
-      </button>
-      <button
-        type="button"
-        onClick={onCancel}
-        className="inline-flex justify-center py-2 px-4 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-        disabled={isSaving}
-        data-testid="editor-cancel-button"
-      >
-        Cancel
-      </button>
     </div>
   );
 }

--- a/frontend/src/shared/lib/api-client.ts
+++ b/frontend/src/shared/lib/api-client.ts
@@ -14,6 +14,8 @@ import {
   CreateProjectRequest,
   UpdateProjectRequest,
   Section,
+  CreateSectionRequest,
+  UpdateSectionRequest,
   ReactionCounts,
   ToggleReactionRequest,
   ToggleReactionResponse,
@@ -152,14 +154,20 @@ const apiRoutes = {
   },
   projects: {
     list: () => '/api/projects',
+    getById: (id: string) => `/api/projects/${id}`,
     getBySlug: (slug: string) => `/api/projects/${slug}`,
     create: () => '/api/projects',
     update: (id: string) => `/api/projects/${id}`,
     delete: (id: string) => `/api/projects/${id}`,
   },
   sections: {
+    list: () => '/api/sections',
+    getById: (id: string) => `/api/sections/${id}`,
     getBySlug: (slug: string) => `/api/sections/by-slug/${slug}`,
     navigation: () => '/api/sections/navigation',
+    create: () => '/api/sections',
+    update: (id: string) => `/api/sections/${id}`,
+    delete: (id: string) => `/api/sections/${id}`,
   },
   engagement: {
     reactions: (targetType: string, targetId: string) =>
@@ -259,6 +267,9 @@ const apiClient = {
         params: pagination as Record<string, string | number>
       }),
 
+    getById: (id: string, token: string) =>
+      fetchApi<Project>(apiRoutes.projects.getById(id), { token }),
+
     getBySlug: (slug: string) =>
       fetchApi<Project>(apiRoutes.projects.getBySlug(slug)),
 
@@ -287,11 +298,37 @@ const apiClient = {
    * Section methods
    */
   sections: {
+    list: (token?: string, params?: Record<string, string | number>) =>
+      fetchApi<PaginatedResponse<Section>>(apiRoutes.sections.list(), { token, params }),
+
+    getById: (id: string, token?: string) =>
+      fetchApi<Section>(apiRoutes.sections.getById(id), { token }),
+
     getBySlug: (slug: string) =>
       fetchApi<Section>(apiRoutes.sections.getBySlug(slug)),
 
     navigation: () =>
       fetchApi<PaginatedResponse<Section>>(apiRoutes.sections.navigation()),
+
+    create: (data: CreateSectionRequest, token: string) =>
+      fetchApi<Section, CreateSectionRequest>(apiRoutes.sections.create(), {
+        method: 'POST',
+        body: data,
+        token,
+      }),
+
+    update: (id: string, data: UpdateSectionRequest, token: string) =>
+      fetchApi<Section, UpdateSectionRequest>(apiRoutes.sections.update(id), {
+        method: 'PUT',
+        body: data,
+        token,
+      }),
+
+    delete: (id: string, token: string) =>
+      fetchApi<void>(apiRoutes.sections.delete(id), {
+        method: 'DELETE',
+        token,
+      }),
   },
 
   /**

--- a/frontend/src/shared/lib/navigation.ts
+++ b/frontend/src/shared/lib/navigation.ts
@@ -3,6 +3,7 @@ import { Section } from '@/shared/types/api';
 export type NavIcon = 'home' | 'user' | 'folder' | 'mail' | 'default';
 
 export interface NavSectionItem {
+    id: string;
     slug: string;
     path: string;
     label: string;
@@ -16,15 +17,9 @@ const SLUG_ICON_MAP: Record<string, NavIcon> = {
     contact: 'mail',
 };
 
-export const FALLBACK_SECTIONS: NavSectionItem[] = [
-    { slug: 'blog', path: '/blog', label: 'Blog', icon: 'home' },
-    { slug: 'about', path: '/about', label: 'About', icon: 'user' },
-    { slug: 'projects', path: '/projects', label: 'Projects', icon: 'folder' },
-    { slug: 'contact', path: '/contact', label: 'Contact', icon: 'mail' },
-];
-
 export function sectionToNavItem(section: Section): NavSectionItem {
     return {
+        id: section.id,
         slug: section.slug,
         path: `/${section.slug}`,
         label: section.title,

--- a/frontend/src/shared/types/api.ts
+++ b/frontend/src/shared/types/api.ts
@@ -31,6 +31,7 @@ export interface Story {
     createdDate: string;
     updatedDate: string;
     user_id?: string;
+    section_id?: string;
 }
 
 /**
@@ -75,6 +76,7 @@ export interface ProjectCard {
     live_url: string | null;
     is_featured: boolean;
     user_id?: string;
+    section_id?: string;
 }
 
 /**
@@ -96,6 +98,7 @@ export interface Project {
     createdDate: string;
     updatedDate: string;
     user_id?: string;
+    section_id?: string;
 }
 
 /**
@@ -112,6 +115,7 @@ export interface CreateProjectRequest {
     is_published?: boolean;
     is_featured?: boolean;
     sort_order?: number;
+    section_id?: string;
 }
 
 /**
@@ -126,6 +130,7 @@ export interface CreateStoryRequest {
     title: string;
     content: string;
     is_published: boolean;
+    section_id?: string;
 }
 
 /**
@@ -164,6 +169,18 @@ export interface Section {
     updatedDate: string;
     user_id?: string;
 }
+
+export interface CreateSectionRequest {
+    title: string;
+    display_type: DisplayType;
+    content_type: SectionContentType;
+    nav_visibility?: NavVisibility;
+    sort_order?: number;
+    is_published?: boolean;
+    parent_id?: string | null;
+}
+
+export type UpdateSectionRequest = Partial<CreateSectionRequest>;
 
 /**
  * Engagement types for reactions and comments


### PR DESCRIPTION
## Summary

- Add section CRUD API proxy routes (`/api/sections`, `/api/sections/[id]`) and api-client methods
- Create `/admin/sections` page for managing sections (create, edit, delete, add content)
- Refactor editor to be section-aware: renders StoryEditorForm, ProjectEditorForm, or PageEditorForm based on section's `content_type`
- Add SectionPicker when navigating to `/editor` without a `section_id`
- Make navigation fully dynamic: remove hardcoded fallback sections, add listener-based cache invalidation so nav updates immediately after section mutations
- Add `section_id` field to Story, Project, and CreateStoryRequest types
- Add Phase 6 plan document to docs-site
- Update all e2e editor tests for section-aware navigation
- 102 Playwright tests passing, 221 backend pytest tests passing

## Test plan

- [x] `make dev` — start local stack, run `make migrate` for fresh DB
- [x] Log in as admin, navigate to `/admin/sections` — verify CRUD operations
- [x] Create a new section with `nav_visibility=main` — verify it appears in nav bar
- [x] Navigate to `/editor` — verify SectionPicker appears
- [x] Navigate to `/editor?section_id=<blog-id>` — verify story form renders
- [x] Navigate to `/editor?section_id=<projects-id>` — verify project form renders
- [x] `cd frontend && npx playwright test` — all 102 tests pass