### PR TITLE
fix: engagement cleanup — #96 #95 #94 #74

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -204,14 +204,13 @@ async def general_exception_handler(request: Request, exc: Exception):
         },
     )
 
-    return JSONResponse(
-        status_code=500,
-        content={
-            "detail": "Internal Server Error",
-            "error_type": type(exc).__name__,
-            "message": str(exc),
-        },
-    )
+    is_dev = os.environ.get("ALLOW_DEV_AUTH") == "true"
+    content: dict = {"detail": "Internal Server Error"}
+    if is_dev:
+        content["error_type"] = type(exc).__name__
+        content["message"] = str(exc)
+
+    return JSONResponse(status_code=500, content=content)
 
 
 @app.get("/health")

--- a/backend/config/engagement.py
+++ b/backend/config/engagement.py
@@ -1,10 +1,4 @@
-"""
-TEMPORARY: Engagement configuration
-
-TODO: Move to section configuration when dynamic section routing
-is implemented. This file should be deleted and engagement settings
-should be defined per-section in the section config system.
-"""
+"""Engagement configuration constants."""
 
 ENGAGEMENT_ENABLED_TYPES: dict[str, dict[str, bool]] = {
     "story": {"reactions": True, "comments": True},
@@ -21,3 +15,12 @@ ALLOWED_REACTION_TAGS: list[str] = [
 
 REALTIME_STRATEGY: str = "websocket"  # or "polling" or "none"
 POLLING_INTERVAL_SECONDS: int = 10
+
+# Query limits
+MAX_REACTIONS_PER_QUERY: int = 1000
+MAX_COMMENTS_PER_QUERY: int = 1000
+
+# Rate limits
+REACTION_RATE_LIMIT: str = "10/minute"
+COMMENT_CREATE_RATE_LIMIT: str = "3/minute"
+COMMENT_DELETE_RATE_LIMIT: str = "10/minute"

--- a/backend/handlers/engagement.py
+++ b/backend/handlers/engagement.py
@@ -227,8 +227,8 @@ async def get_comments(
             "user_avatar": comment.get("user_avatar"),
             "content": comment["content"],
             "mentions": comment.get("mentions", []),
-            "created_at": comment["created_at"].isoformat(),
-            "updated_at": comment["updated_at"].isoformat(),
+            "created_at": comment["created_at"],
+            "updated_at": comment["updated_at"],
             "deleted_at": None,
             "replies": [],
         }
@@ -323,8 +323,8 @@ async def create_comment(
         "user_avatar": created.get("user_avatar"),
         "content": created["content"],
         "mentions": created.get("mentions", []),
-        "created_at": created["created_at"].isoformat(),
-        "updated_at": created["updated_at"].isoformat(),
+        "created_at": created["created_at"],
+        "updated_at": created["updated_at"],
         "deleted_at": None,
         "replies": [],
     }

--- a/backend/handlers/engagement.py
+++ b/backend/handlers/engagement.py
@@ -3,7 +3,14 @@
 from datetime import datetime, timezone
 
 from bson import ObjectId
-from config.engagement import ENGAGEMENT_ENABLED_TYPES
+from config.engagement import (
+    COMMENT_CREATE_RATE_LIMIT,
+    COMMENT_DELETE_RATE_LIMIT,
+    ENGAGEMENT_ENABLED_TYPES,
+    MAX_COMMENTS_PER_QUERY,
+    MAX_REACTIONS_PER_QUERY,
+    REACTION_RATE_LIMIT,
+)
 from database import (
     get_collection,
     get_comments_collection,
@@ -14,12 +21,13 @@ from decorators.auth import requires_auth
 from fastapi import APIRouter, Depends, HTTPException, Request
 from glogger import logger
 from middleware.rate_limit import limiter
-from models.comment import CommentCreate
+from models.comment import CommentCreate, CommentResponse, CommentsListResponse
 from models.reaction import (
     BulkCountsRequest,
     BulkCountsResponse,
     ReactionCounts,
     ReactionCreate,
+    ToggleReactionResponse,
 )
 from models.user import UserInfo
 from motor.motor_asyncio import AsyncIOMotorCollection
@@ -93,7 +101,7 @@ async def get_reactions(
 
     # Get all reactions for this target
     cursor = reactions_collection.find({"target_type": target_type, "target_id": target_id})
-    reactions = await cursor.to_list(length=1000)
+    reactions = await cursor.to_list(length=MAX_REACTIONS_PER_QUERY)
 
     # Build counts and details
     counts: dict[str, int] = {}
@@ -120,8 +128,8 @@ async def get_reactions(
     return ReactionCounts(counts=counts, user_reactions=user_reactions, details=details)
 
 
-@router.post("/{target_type}/{target_id}/reactions")
-@limiter.limit("10/minute")
+@router.post("/{target_type}/{target_id}/reactions", response_model=ToggleReactionResponse)
+@limiter.limit(REACTION_RATE_LIMIT)
 @requires_auth
 async def toggle_reaction(
     request: Request,
@@ -129,7 +137,7 @@ async def toggle_reaction(
     target_id: str,
     reaction: ReactionCreate,
     reactions_collection: AsyncIOMotorCollection = Depends(get_reactions_collection),
-) -> dict:
+):
     """Toggle a reaction (add if missing, remove if exists). Requires auth."""
     validate_target_type(target_type, "reactions")
     validate_object_id(target_id, "target ID")
@@ -177,13 +185,13 @@ async def toggle_reaction(
         return {"added": True, "reaction_tag": reaction.reaction_tag}
 
 
-@router.get("/{target_type}/{target_id}/comments")
+@router.get("/{target_type}/{target_id}/comments", response_model=CommentsListResponse)
 async def get_comments(
     request: Request,
     target_type: str,
     target_id: str,
     comments_collection: AsyncIOMotorCollection = Depends(get_comments_collection),
-) -> dict:
+):
     """Get comments for a target with nested replies. Public endpoint."""
     validate_target_type(target_type, "comments")
     validate_object_id(target_id, "target ID")
@@ -202,7 +210,7 @@ async def get_comments(
         }
     ).sort("created_at", 1)
 
-    all_comments = await cursor.to_list(length=1000)
+    all_comments = await cursor.to_list(length=MAX_COMMENTS_PER_QUERY)
 
     # Build nested structure
     comments_by_id: dict[str, dict] = {}
@@ -238,8 +246,12 @@ async def get_comments(
     return {"comments": top_level}
 
 
-@router.post("/{target_type}/{target_id}/comments", status_code=201)
-@limiter.limit("3/minute")
+@router.post(
+    "/{target_type}/{target_id}/comments",
+    status_code=201,
+    response_model=CommentResponse,
+)
+@limiter.limit(COMMENT_CREATE_RATE_LIMIT)
 @requires_auth
 async def create_comment(
     request: Request,
@@ -247,7 +259,7 @@ async def create_comment(
     target_id: str,
     comment: CommentCreate,
     comments_collection: AsyncIOMotorCollection = Depends(get_comments_collection),
-) -> dict:
+):
     """Create a new comment. Requires auth."""
     validate_target_type(target_type, "comments")
     validate_object_id(target_id, "target ID")
@@ -319,7 +331,7 @@ async def create_comment(
 
 
 @router.delete("/comments/{comment_id}", status_code=204)
-@limiter.limit("10/minute")
+@limiter.limit(COMMENT_DELETE_RATE_LIMIT)
 @requires_auth
 async def delete_comment(
     request: Request,

--- a/backend/models/comment.py
+++ b/backend/models/comment.py
@@ -48,5 +48,12 @@ class CommentResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class CommentsListResponse(BaseModel):
+    """Response model for listing comments."""
+
+    comments: list[CommentResponse]
+
+
 # Enable forward reference for nested replies
 CommentResponse.model_rebuild()
+CommentsListResponse.model_rebuild()

--- a/backend/models/reaction.py
+++ b/backend/models/reaction.py
@@ -53,6 +53,13 @@ class ReactionCounts(BaseModel):
     details: dict[str, list[dict[str, str]]] = Field(default_factory=dict)
 
 
+class ToggleReactionResponse(BaseModel):
+    """Response model for toggling a reaction."""
+
+    added: bool
+    reaction_tag: str
+
+
 class BulkCountsRequest(BaseModel):
     """Request model for bulk counts endpoint."""
 

--- a/frontend/src/modules/engagement/components/CommentSection.tsx
+++ b/frontend/src/modules/engagement/components/CommentSection.tsx
@@ -3,6 +3,7 @@ import { useSession } from 'next-auth/react';
 import { Comment } from '@/shared/types/api';
 import { CommentThread } from './CommentThread';
 import { Button, Textarea } from '@/components/ui';
+import { InlineError } from '@/components/ErrorDisplay';
 
 interface CommentSectionProps {
   comments: Comment[];
@@ -58,11 +59,7 @@ export function CommentSection({
         Comments {totalComments > 0 && `(${totalComments})`}
       </h3>
 
-      {error && (
-        <p className="text-sm text-red-600 dark:text-red-400">
-          Failed to load comments. Please refresh the page.
-        </p>
-      )}
+      <InlineError error={error ? "Failed to load comments. Please refresh the page." : null} />
 
       {/* New comment input */}
       {session ? (
@@ -81,9 +78,7 @@ export function CommentSection({
           >
             {isSubmitting ? 'Posting...' : 'Post Comment'}
           </Button>
-          {submitError && (
-            <p className="text-sm text-red-600 dark:text-red-400">{submitError}</p>
-          )}
+          <InlineError error={submitError} />
         </div>
       ) : (
         <p className="text-gray-500">Sign in to leave a comment</p>

--- a/frontend/src/modules/engagement/components/CommentSection.tsx
+++ b/frontend/src/modules/engagement/components/CommentSection.tsx
@@ -9,6 +9,7 @@ interface CommentSectionProps {
   onAddComment: (content: string, parentId?: string | null) => Promise<void>;
   onDeleteComment: (commentId: string) => Promise<void>;
   isLoading?: boolean;
+  error?: Error | null;
 }
 
 export function CommentSection({
@@ -16,17 +17,22 @@ export function CommentSection({
   onAddComment,
   onDeleteComment,
   isLoading = false,
+  error = null,
 }: CommentSectionProps) {
   const { data: session } = useSession();
   const [newComment, setNewComment] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const handleSubmit = async () => {
     if (!newComment.trim()) return;
     setIsSubmitting(true);
+    setSubmitError(null);
     try {
       await onAddComment(newComment);
       setNewComment('');
+    } catch {
+      setSubmitError('Failed to post comment. Please try again.');
     } finally {
       setIsSubmitting(false);
     }
@@ -52,6 +58,12 @@ export function CommentSection({
         Comments {totalComments > 0 && `(${totalComments})`}
       </h3>
 
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400">
+          Failed to load comments. Please refresh the page.
+        </p>
+      )}
+
       {/* New comment input */}
       {session ? (
         <div className="space-y-2">
@@ -69,6 +81,9 @@ export function CommentSection({
           >
             {isSubmitting ? 'Posting...' : 'Post Comment'}
           </Button>
+          {submitError && (
+            <p className="text-sm text-red-600 dark:text-red-400">{submitError}</p>
+          )}
         </div>
       ) : (
         <p className="text-gray-500">Sign in to leave a comment</p>

--- a/frontend/src/modules/engagement/components/ReactionBar.tsx
+++ b/frontend/src/modules/engagement/components/ReactionBar.tsx
@@ -32,6 +32,7 @@ export function ReactionBar({ reactions, onToggle, compact = false }: ReactionBa
       await onToggle(tag);
     } catch {
       setToggleError(true);
+      if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
       errorTimerRef.current = setTimeout(() => setToggleError(false), 3000);
     } finally {
       setIsLoading(false);

--- a/frontend/src/modules/engagement/components/ReactionBar.tsx
+++ b/frontend/src/modules/engagement/components/ReactionBar.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { ReactionCounts, ReactionTag } from '@/shared/types/api';
 import { engagementConfig } from '@/config/engagement.config';
+import { InlineError } from '@/components/ErrorDisplay';
 
 interface ReactionBarProps {
   reactions: ReactionCounts | null;
@@ -17,6 +18,11 @@ export function ReactionBar({ reactions, onToggle, compact = false }: ReactionBa
   const [showPicker, setShowPicker] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [toggleError, setToggleError] = useState(false);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => { if (errorTimerRef.current) clearTimeout(errorTimerRef.current); };
+  }, []);
 
   const handleToggle = async (tag: ReactionTag) => {
     if (!session) return;
@@ -26,7 +32,7 @@ export function ReactionBar({ reactions, onToggle, compact = false }: ReactionBa
       await onToggle(tag);
     } catch {
       setToggleError(true);
-      setTimeout(() => setToggleError(false), 3000);
+      errorTimerRef.current = setTimeout(() => setToggleError(false), 3000);
     } finally {
       setIsLoading(false);
       setShowPicker(false);
@@ -118,9 +124,7 @@ export function ReactionBar({ reactions, onToggle, compact = false }: ReactionBa
           )}
         </div>
       )}
-      {toggleError && (
-        <span className="text-xs text-red-600 dark:text-red-400">Failed</span>
-      )}
+      <InlineError error={toggleError ? "Failed" : null} />
     </div>
   );
 }

--- a/frontend/src/modules/engagement/components/ReactionBar.tsx
+++ b/frontend/src/modules/engagement/components/ReactionBar.tsx
@@ -16,12 +16,17 @@ export function ReactionBar({ reactions, onToggle, compact = false }: ReactionBa
   const { data: session } = useSession();
   const [showPicker, setShowPicker] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [toggleError, setToggleError] = useState(false);
 
   const handleToggle = async (tag: ReactionTag) => {
     if (!session) return;
     setIsLoading(true);
+    setToggleError(false);
     try {
       await onToggle(tag);
+    } catch {
+      setToggleError(true);
+      setTimeout(() => setToggleError(false), 3000);
     } finally {
       setIsLoading(false);
       setShowPicker(false);
@@ -112,6 +117,9 @@ export function ReactionBar({ reactions, onToggle, compact = false }: ReactionBa
             </div>
           )}
         </div>
+      )}
+      {toggleError && (
+        <span className="text-xs text-red-600 dark:text-red-400">Failed</span>
       )}
     </div>
   );

--- a/frontend/src/pages/[...slugPath].tsx
+++ b/frontend/src/pages/[...slugPath].tsx
@@ -41,7 +41,7 @@ interface SectionPageProps {
 }
 
 function StoryEngagement() {
-    const { reactions, comments, isLoading, toggleReaction, addComment, deleteComment } = useEngagementContext();
+    const { reactions, comments, isLoading, error, toggleReaction, addComment, deleteComment } = useEngagementContext();
 
     return (
         <>
@@ -57,6 +57,7 @@ function StoryEngagement() {
                     onAddComment={addComment}
                     onDeleteComment={deleteComment}
                     isLoading={isLoading}
+                    error={error}
                 />
             </div>
         </>


### PR DESCRIPTION
## Summary
- **#96**: Extract magic numbers (query limits, rate limit strings) to `config/engagement.py` constants
- **#95**: Add `response_model` to `toggle_reaction`, `get_comments`, `create_comment` using existing Pydantic models (`ToggleReactionResponse`, `CommentsListResponse`, `CommentResponse`)
- **#94**: Add error display to `CommentSection` (fetch errors + submit errors) and `ReactionBar` (toggle failure indicator)
- **#74**: Gate internal error details (`error_type`, `message`) in the general exception handler behind `ALLOW_DEV_AUTH` — production returns only `"Internal Server Error"`

## Test plan
- [ ] Reaction toggle still works (add/remove)
- [ ] Comments still load, create, delete
- [ ] Error message shows when comment submit fails
- [ ] Error message shows when comment fetch fails
- [ ] Production 500 responses contain no internal details
- [ ] Dev 500 responses still show error_type and message