### PR TITLE
Show add content button on mobile in section admin bar

### DIFF
--- a/frontend/src/components/SectionAdminBar.tsx
+++ b/frontend/src/components/SectionAdminBar.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { useSession } from "next-auth/react";
+import { HiPlus } from "react-icons/hi";
 
 interface SectionAdminBarProps {
   sectionId: string;
@@ -11,17 +12,19 @@ export function SectionAdminBar({ sectionId }: SectionAdminBarProps) {
   if (session?.user?.role !== "admin") return null;
 
   return (
-    <div className="hidden md:flex gap-2 mb-md" data-testid="section-admin-bar">
+    <div className="flex gap-2 mb-md" data-testid="section-admin-bar">
       <Link
         href={{ pathname: "/editor", query: { section_id: sectionId } }}
         className="btn btn--primary btn--sm"
         data-testid="section-add-content"
       >
-        Add Content
+        <HiPlus className="md:hidden" aria-hidden="true" />
+        <span className="hidden md:inline">Add Content</span>
+        <span className="md:hidden">Add</span>
       </Link>
       <Link
         href={{ pathname: "/admin", query: { section: sectionId } }}
-        className="btn btn--secondary btn--sm"
+        className="btn btn--secondary btn--sm hidden md:inline-flex"
         data-testid="section-manage"
       >
         Manage Section


### PR DESCRIPTION
The SectionAdminBar was hidden entirely on mobile (hidden md:flex),
leaving admins with no way to add content from a phone. The bar is
now visible at all breakpoints with a compact "Add" label and plus
icon on mobile. "Manage Section" stays desktop-only since Master
Control is not available on mobile.

https://claude.ai/code/session_01SEy8L7ZgKR8hGCQuXPhjqc