### PR TITLE
Address Vibe Check security scan findings

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -30,6 +30,7 @@ from handlers.stories import router as stories_router
 from handlers.tags import router as tags_router
 from handlers.tailor import router as tailor_router
 from handlers.uploads import router as uploads_router
+from handlers.uploads import validate_storage_config
 from handlers.users import router as users_router
 from handlers.versions import router as versions_router
 from handlers.video_processing import router as video_processing_router
@@ -68,6 +69,10 @@ async def lifespan(app: FastAPI):
         )
     if google_creds_file:
         logger.info(f"GOOGLE_APPLICATION_CREDENTIALS file path: {google_creds_file}")
+
+    validate_storage_config()
+    logger.info("Storage configuration validated")
+
     updated_count = await backfill_published_flag()
     logger.info(f"Startup complete. Backfilled {updated_count} stories.")
 

--- a/backend/handlers/sections.py
+++ b/backend/handlers/sections.py
@@ -7,7 +7,11 @@ from datetime import datetime, timezone
 
 from bson import ObjectId
 from database import get_sections_collection
-from decorators.auth import check_write_permission, requires_auth, verify_auth
+from decorators.auth import (
+    check_write_permission,
+    requires_auth,
+    verify_auth_and_get_user,
+)
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from glogger import logger
 from middleware.rate_limit import limiter
@@ -88,13 +92,15 @@ async def get_sections(
         include_unpublished: Include unpublished sections (requires auth)
     """
     try:
-        # Require authentication to view unpublished sections
+        user: UserInfo | None = None
         if include_unpublished:
-            await verify_auth(request)
+            user = await verify_auth_and_get_user(request)
 
         query = {"deleted": {"$ne": True}}
         if not include_unpublished:
             query["is_published"] = True
+        elif user is not None and user.role != "admin":
+            query["user_id"] = user.id
         if parent_id is not None:
             if parent_id != "null" and not ObjectId.is_valid(parent_id):
                 raise HTTPException(status_code=400, detail="Invalid parent_id format")

--- a/backend/handlers/stories.py
+++ b/backend/handlers/stories.py
@@ -30,18 +30,22 @@ async def get_stories(
     collection: AsyncIOMotorCollection = Depends(get_collection),
 ):
     try:
-        # Only allow include_drafts for authenticated admin users
         drafts_allowed = False
+        draft_owner_filter: str | None = None
         if include_drafts:
             try:
                 user = await verify_auth_and_get_user(request)
-                drafts_allowed = user.role == "admin"
+                drafts_allowed = True
+                if user.role != "admin":
+                    draft_owner_filter = user.id
             except HTTPException:
                 drafts_allowed = False
 
         query = {"deleted": {"$ne": True}}
         if not drafts_allowed:
             query["is_published"] = True
+        elif draft_owner_filter is not None:
+            query["user_id"] = draft_owner_filter
         if section_id:
             query["section_id"] = section_id
         sort = {"createdDate": -1}

--- a/backend/handlers/uploads.py
+++ b/backend/handlers/uploads.py
@@ -103,6 +103,38 @@ if not LOCAL_STORAGE_PATH:
     from google.cloud import storage
     from google.oauth2 import service_account
 
+
+def validate_storage_config() -> None:
+    """Validate storage configuration at startup.
+
+    Ensures credentials resolve to a working GCS auth source before the app
+    accepts traffic. Workload Identity (no credential env vars set) is
+    treated as valid when GCS_BUCKET_NAME is set — Cloud Run supplies the
+    service account identity via the metadata server.
+
+    Raises RuntimeError if GOOGLE_APPLICATION_CREDENTIALS_JSON is set but
+    invalid JSON, or GOOGLE_APPLICATION_CREDENTIALS points to a missing
+    file, or no storage backend is configured at all.
+    """
+    if LOCAL_STORAGE_PATH:
+        return
+    if not GCS_BUCKET_NAME:
+        raise RuntimeError(
+            "Storage misconfigured: set GCS_BUCKET_NAME (GCS) or LOCAL_STORAGE_PATH (local dev)."
+        )
+    creds_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
+    if creds_json:
+        try:
+            json.loads(creds_json)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"GOOGLE_APPLICATION_CREDENTIALS_JSON is not valid JSON: {exc}"
+            ) from exc
+    creds_file = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if creds_file and not os.path.isfile(creds_file):
+        raise RuntimeError(f"GOOGLE_APPLICATION_CREDENTIALS points to a missing file: {creds_file}")
+
+
 # Allowed origins for CORS
 ALLOWED_ORIGINS = [
     "https://ghostmonk.com",

--- a/backend/services/anthropic_client.py
+++ b/backend/services/anthropic_client.py
@@ -65,11 +65,9 @@ def get_client() -> anthropic.Anthropic:
         with _client_lock:
             if _client is None:
                 api_key = os.getenv("ANTHROPIC_API_KEY")
-                if not api_key:
-                    raise ServiceNotConfiguredError(
-                        "ANTHROPIC_API_KEY environment variable is required"
-                    )
-                _client = anthropic.Anthropic(api_key=api_key)
+                if not api_key or not api_key.strip():
+                    raise ServiceNotConfiguredError("ANTHROPIC_API_KEY must be set and non-empty")
+                _client = anthropic.Anthropic(api_key=api_key.strip())
     return _client
 
 


### PR DESCRIPTION
## Summary

Triaged 4 findings from a Vibe Check security scan. Three required code changes; one was a false positive that would have regressed PR #191.

## Findings and actions

**#1 — [HIGH] BOLA on `/sections?include_unpublished=true` — FIXED**

Before: `include_unpublished` only called `verify_auth(request)`, so any authenticated user (including `commenter` role via Google OAuth) could enumerate unpublished section metadata.

After: swap to `verify_auth_and_get_user`. Non-admin callers get `query[\"user_id\"] = user.id` appended to the query. In this single-admin CMS non-admins own zero sections, so the flag effectively becomes admin-only without crashing non-admin callers.

**#2 — [HIGH] BOLA on `/stories?include_drafts=true` — FIXED (adapted)**

Scanner suggested gating on `super_admin` — that role does not exist in this codebase (`UserRole = Literal[\"admin\", \"commenter\"]`). Applied literally it would have hidden drafts from the actual admin.

Adapted fix: `include_drafts=true` returns drafts for admin (unchanged); for non-admin it filters `query[\"user_id\"] = user.id`. Commenter-authored drafts stay owner-scoped.

**#3 — [MEDIUM] Missing GCS credential validation — FIXED (architecturally compatible)**

Scanner's literal suggestion (\"check GOOGLE_APPLICATION_CREDENTIALS or GOOGLE_APPLICATION_CREDENTIALS_JSON is set and valid\") would have broken production, which uses Workload Identity via `--service-account` with neither env var set. See PR #191.

Instead: new `validate_storage_config()` in `uploads.py`, called from the `lifespan` in `app.py`. Fails fast on:
- `GCS_BUCKET_NAME` missing (and no `LOCAL_STORAGE_PATH`)
- `GOOGLE_APPLICATION_CREDENTIALS_JSON` set but not parseable JSON
- `GOOGLE_APPLICATION_CREDENTIALS` set but pointing at a missing file

When neither env var is set, the function returns normally — ADC via the Cloud Run metadata server handles auth.

**#4 — [MEDIUM] Anthropic API key validation — FIXED**

Before: `if not api_key:` caught unset / empty-string but not whitespace-only.

After: `if not api_key or not api_key.strip():` with a matching error message. Key is stripped before being passed to `anthropic.Anthropic(api_key=...)`.

## Tests

- Backend pytest: **521 passed** locally.
- No existing tests covered the `include_unpublished=true` or `include_drafts=true` code paths; the two BOLA changes are additive filters that don't alter the default public responses exercised by existing tests.

## Out of scope

- Adding explicit tests for admin-vs-commenter visibility on sections/stories drafts (happy to add in a follow-up PR if desired).
- The broader question of whether commenter-role users should be able to create stories/sections at all (currently `@requires_auth` allows it; ownership checks on update/delete prevent cross-user mutation).